### PR TITLE
Add support for FASTNEAR_API_KEY environment variable

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,6 +65,7 @@ Built files are output to the `dist/` directory.
 
 - `NEAR_RPC_ENDPOINT` - RPC endpoint URL (default: https://archival-rpc.mainnet.fastnear.com)
   - **Note**: The old rpc.mainnet.near.org endpoint is deprecated and returns error -429. Use fastnear.com or alternative providers from https://docs.near.org/api/rpc/providers
+- `FASTNEAR_API_KEY` - FastNEAR API key for higher rate limits (optional). When set, adds `Authorization: Bearer <key>` header to all RPC requests
 - `RPC_DELAY_MS` - Delay between RPC calls in milliseconds (default: 50)
 
 ## Key Conventions

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The script automatically:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `NEAR_RPC_ENDPOINT` | RPC endpoint URL | `https://archival-rpc.mainnet.fastnear.com` |
+| `FASTNEAR_API_KEY` | FastNEAR API key for higher rate limits | None |
 | `RPC_DELAY_MS` | Delay between RPC calls in ms | `50` |
 
 ## Output Format


### PR DESCRIPTION
## Summary

Adds support for the `FASTNEAR_API_KEY` environment variable to enable higher rate limits when using FastNEAR's archival RPC endpoint.

## Changes

- Added `getRpcHeaders()` helper function in `scripts/rpc.ts` to include `Authorization: Bearer <key>` header when API key is set
- Pass headers to `NearRpcClient` constructor for all RPC calls via the library
- Include Authorization header in direct fetch calls (`getTransactionStatusWithReceipts`)
- Updated documentation in `README.md` and `.github/copilot-instructions.md`

## Usage

```bash
# With Docker
docker run -v $(pwd)/data:/data \
  -e FASTNEAR_API_KEY=your-api-key \
  near-accounting-export \
  --account myaccount.near \
  --output /data/myaccount.json \
  --max 50

# Direct
export FASTNEAR_API_KEY=your-api-key
npm start -- --account myaccount.near --max 50
```

## Testing

Tested locally with a FastNEAR API key - successfully fetched 50+ transactions without rate limiting.