### PR TITLE
fix: exclude staking-only entries from gap detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,37 @@ The output JSON file contains:
 npm test
 ```
 
+## CSV Export
+
+Convert the JSON accounting history to CSV format for import into spreadsheet software:
+
+```bash
+# Convert JSON to CSV (output file will be myaccount.near.csv)
+node dist/scripts/json-to-csv.js myaccount.near.json
+
+# Specify custom output file
+node dist/scripts/json-to-csv.js -i myaccount.near.json -o accounting.csv
+
+# Using long options
+node dist/scripts/json-to-csv.js --input myaccount.near.json --output accounting.csv
+```
+
+### CSV Columns
+
+| Column | Description |
+|--------|-------------|
+| `block_height` | Block number where the transfer occurred |
+| `timestamp` | ISO 8601 timestamp of the transfer |
+| `asset` | Token identifier (NEAR for native, contract address for FT/MT, STAKING:pool for staking rewards) |
+| `counterparty` | The other account involved in the transfer |
+| `direction` | "in" for incoming, "out" for outgoing transfers |
+| `amount` | Amount transferred (in smallest units) |
+| `transaction_hash` | Hash of the transaction |
+| `receipt_id` | Receipt ID of the transfer |
+| `token_balance` | Balance of the token after the block |
+
+**Note:** If timestamps are missing in the JSON, re-run `get-account-history.js` with the `--enrich` flag to fetch missing timestamps before converting to CSV.
+
 ## License
 
 ISC


### PR DESCRIPTION
## Problem

When running the script multiple times, it was detecting the same 42 gaps on every run because staking reward entries (synthetic entries created for tracking staking rewards at epoch boundaries) were included in the gap detection.

These entries have `balanceBefore.near: '0'` and empty `fungibleTokens`/`intentsTokens` since they only track staking pool balances. When compared with regular transactions that have actual NEAR balances, they caused false gap detection.

## Solution

1. Added `isStakingOnlyEntry()` function to identify synthetic staking reward entries (entries with no transaction hashes, staking changes, and no other balance changes)
2. Updated `detectGaps()` to filter out staking-only entries before checking connectivity
3. Updated `verifyHistoryFile()` to also filter out staking-only entries for consistency

## Changes

- `scripts/get-account-history.ts`: Add `isStakingOnlyEntry()` helper, export it and `TransactionEntry` type, filter staking-only entries in gap detection
- `test/accounting.test.ts`: Add tests for staking-only entry identification and gap detection
- `README.md`: Add CSV export documentation

## Testing

- Added unit test for `isStakingOnlyEntry()` function
- Added integration test verifying staking-only entries don't cause false gap detection
- All 50 tests pass