### PR TITLE
Fix staking snapshots creating entries every sync cycle instead of per epoch

### DIFF
--- a/scripts/get-account-history.ts
+++ b/scripts/get-account-history.ts
@@ -451,13 +451,11 @@ export async function collectStakingRewards(
             }
         }
         
-        // Also check the final block if it's not an epoch boundary
-        if (range.endBlock > firstEpochBoundary && range.endBlock % EPOCH_LENGTH !== 0) {
-            const key = `${range.endBlock}:${range.pool}`;
-            if (!existingStakingData.has(key)) {
-                epochBoundaries.push(range.endBlock);
-            }
-        }
+        // Note: We intentionally do NOT check the "final block" if it's not at an epoch boundary.
+        // Staking rewards only accrue at epoch boundaries (every 43200 blocks / ~12 hours).
+        // Checking non-epoch blocks during frequent sync cycles would create redundant entries
+        // since the balance won't have changed from rewards within an incomplete epoch.
+        // Withdrawal transactions are captured separately as regular transfers.
         
         const totalEpochs = Math.ceil((range.endBlock - firstEpochBoundary) / EPOCH_LENGTH);
         const alreadyChecked = totalEpochs - epochBoundaries.length;


### PR DESCRIPTION
## Summary

- Fixed bug where staking_reward entries were created every sync cycle (~10 minutes) instead of only at epoch boundaries (~12 hours)
- Removed the "final block" check that was adding current block height for active pools

## Problem

The "final block" check (lines 454-460) was adding `currentBlockHeight` to epoch boundaries for active staking pools. Since `currentBlockHeight` changes every sync cycle and is never at an epoch boundary, this caused:

- **petersalomonsen.near**: 17,550 redundant staking entries in just 3 weeks (since Jan 2, 2026)
- **54MB JSON file** instead of ~10MB expected
- ~62% of all entries were redundant staking snapshots

## Root Cause

For active pools, `range.endBlock` was set to `currentBlockHeight`, and the check:
```typescript
if (range.endBlock > firstEpochBoundary && range.endBlock % EPOCH_LENGTH !== 0) {
    epochBoundaries.push(range.endBlock);
}
```
Would always add a new entry since `currentBlockHeight` is never at an epoch boundary.

## Solution

Removed the "final block" check entirely since:
1. Staking rewards only accrue at epoch boundaries (every 43,200 blocks / ~12 hours)
2. Checking non-epoch blocks provides no value - balance won't have changed
3. Withdrawal transactions are captured separately as regular transfers

## Test plan

- [x] Build passes (`npm run build`)
- [x] Unit tests pass (`npm run test:unit`)
- [x] Deployed to fly.io and verified health check

Fixes #34

🤖 Generated with [Claude Code](https://claude.ai/code)