### PR TITLE
Fix staking rewards lost after unstake + re-stake in same batch

### DIFF
--- a/scripts/get-account-history.ts
+++ b/scripts/get-account-history.ts
@@ -975,9 +975,21 @@ export async function collectStakingRewards(
             );
             
             if (BigInt(balanceAfterWithdrawal[range.pool] || '0') === 0n) {
-                // Full withdrawal - only check epochs up to the withdrawal
-                endBlock = range.lastWithdrawalBlock;
-                console.log(`  ${range.pool}: active from block ${range.firstDepositBlock} to ${endBlock} (fully withdrawn)`);
+                // Balance was 0 shortly after withdrawal — but check current block
+                // in case the account re-staked shortly after (unstake + re-deposit
+                // within the same transaction batch can create a brief zero-balance gap)
+                const currentBalance = await getStakingPoolBalances(
+                    accountId, currentBlockHeight, [range.pool]
+                );
+                if (BigInt(currentBalance[range.pool] || '0') > 0n) {
+                    // Re-staked after withdrawal — continue tracking
+                    endBlock = currentBlockHeight;
+                    console.log(`  ${range.pool}: active from block ${range.firstDepositBlock} to ${endBlock} (re-staked after withdrawal)`);
+                } else {
+                    // Full withdrawal - only check epochs up to the withdrawal
+                    endBlock = range.lastWithdrawalBlock;
+                    console.log(`  ${range.pool}: active from block ${range.firstDepositBlock} to ${endBlock} (fully withdrawn)`);
+                }
             } else {
                 // Partial withdrawal - still active, check to current block height
                 endBlock = currentBlockHeight;

--- a/test/integration/staking.test.ts
+++ b/test/integration/staking.test.ts
@@ -164,4 +164,36 @@ describe('Staking Balance Tracking', () => {
             assert.ok(BigInt(stakingChange!.endBalance) > BigInt('999000000000000000000000000'));
         });
     });
+
+    describe('Unstake + re-stake in same transaction batch (neardevgov pool)', () => {
+        /**
+         * Regression test for: staking rewards lost after unstake + re-stake in same batch.
+         *
+         * petersalomonsen.near unstaked from neardevgov.poolv1.near at block 114812582,
+         * balance hit 0, then re-deposited 100 NEAR at block 114812640 (~57 blocks later).
+         * The old logic checked balance at lastWithdrawalBlock + 10 and saw 0, marking the
+         * pool as fully withdrawn — missing all subsequent staking rewards.
+         */
+        it('should show 0 balance at withdrawal block + 10 (the gap)', async () => {
+            const balances = await getStakingPoolBalances(
+                'petersalomonsen.near',
+                114812583 + 10, // lastWithdrawalBlock + 10
+                ['neardevgov.poolv1.near']
+            );
+            // Balance is 0 in the gap between unstake and re-deposit
+            assert.equal(balances['neardevgov.poolv1.near'], '0');
+        });
+
+        it('should show non-zero balance at a later block after re-stake', async () => {
+            const balances = await getStakingPoolBalances(
+                'petersalomonsen.near',
+                183000000,
+                ['neardevgov.poolv1.near']
+            );
+            const balance = BigInt(balances['neardevgov.poolv1.near'] || '0');
+            // Should have approximately 104-106 NEAR staked
+            assert.ok(balance > BigInt('100000000000000000000000000'),
+                `Expected > 100 NEAR staked, got ${balance}`);
+        });
+    });
 });


### PR DESCRIPTION
## Summary

- When an account unstakes and re-deposits to the same pool within ~60 blocks, the balance check at `lastWithdrawalBlock + 10` sees 0 and incorrectly marks the pool as fully withdrawn, stopping all reward tracking
- Added a fallback check at the current block height — if the pool has a non-zero balance now, it continues tracking rewards
- Existing data self-heals on the next sync cycle (no manual intervention needed)

**Affected**: `petersalomonsen.near` / `neardevgov.poolv1.near` — ~1.475 NEAR in missing staking rewards (Nov/Dec 2024)

## Test plan

- [x] Integration tests verify the zero-balance gap at `lastWithdrawalBlock + 10` and non-zero balance at a later block
- [ ] Verify `petersalomonsen.near` staking rewards appear after next sync cycle on fly.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)