### PR TITLE
Add prepare script so git-URL installs build dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "tsc",
     "prebuild": "rm -rf dist",
+    "prepare": "npm run build",
     "start": "npm run build && node dist/scripts/get-account-history.js",
     "api": "npm run build && node dist/scripts/api-server.js",
     "json-to-csv": "npm run build && node dist/scripts/json-to-csv.js",


### PR DESCRIPTION
## Summary

Adds a single line to \`package.json\` so installs via git URL (e.g. \`github:PeterSalomonsen/near-accounting-export#<sha>\`) build \`dist/\` automatically.

## Why

The \`exports\` field added in #43 points at \`./dist/scripts/index.js\`, but \`dist/\` isn't committed — it's built locally via \`tsc\`. When a consumer installs this package via a git URL, npm clones the source but doesn't run a build, so the \`exports\` targets don't exist and imports of \`createRouter\` / \`startWorker\` fail with \"Cannot find module 'near-accounting-export'\".

Currently consumers have to work around this with a custom postinstall script that runs \`npm install && npm run build\` inside \`node_modules/near-accounting-export/\` (e.g. arizas/ariz-gateway#9 added one). That:

- Pushes a build concern into the wrong repo
- Pulls upstream devDeps into the consumer image
- Requires the consumer's Dockerfile to know about the upstream's build process

## Fix

\`\`\`json
\"scripts\": {
  ...
  \"prepare\": \"npm run build\"
}
\`\`\`

npm runs \`prepare\` automatically after installing from a git URL — installs devDeps, runs prepare (which runs \`tsc\`), prunes devDeps. Standard pattern for git-URL-installed TypeScript packages. After this lands, consumers like ariz-gateway can drop their postinstall workaround entirely.

## Test plan

- [x] \`npm test\` still passes (no behavioural change to source).
- [ ] After merge: in arizas/ariz-gateway, bump the pinned SHA to the merge commit, drop \`scripts/build-near-accounting-export.js\` + the \`postinstall\` line + the Dockerfile \`COPY scripts scripts\`, confirm the gateway still builds and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)