### PR TITLE
Extend transfers-API sync to NEAR Intents balances (NEP-245)

### DIFF
--- a/scripts/api-server.ts
+++ b/scripts/api-server.ts
@@ -679,18 +679,19 @@ export async function startWorker(config: WorkerConfig = {}): Promise<WorkerHand
                     console.error(`[${accountId}] Forward search failed:`, error);
                 }
 
-                // Authoritative FT records from the FastNear Transfers API.
-                // Runs every cycle: it reports each FT transfer at its real
-                // settlement block with start/end-of-block balances, capturing
-                // multi-hop claims the block-sampling path misses (see
-                // transfers-sync.ts). Incremental after the latest stored FT block.
+                // Authoritative FT + NEAR Intents records from the FastNear
+                // Transfers API. Runs every cycle: it reports each transfer at its
+                // real settlement block with start/end-of-block balances, capturing
+                // multi-hop transfers the block-sampling path misses — FT claims
+                // and intents deposits (see transfers-sync.ts). Incremental after
+                // the latest stored owned block.
                 try {
-                    const ftSync = await syncFtTransfersForAccount(accountId, outputFile);
-                    if (ftSync.changed) {
-                        console.log(`[${accountId}] FT transfers sync: +${ftSync.fetched} fetched, ${ftSync.gaps.length} gap(s), ${ftSync.filled} reconciled`);
+                    const txSync = await syncFtTransfersForAccount(accountId, outputFile);
+                    if (txSync.changed) {
+                        console.log(`[${accountId}] Transfers sync: +${txSync.fetched} fetched, ${txSync.gaps.length} gap(s), ${txSync.filled} reconciled${txSync.backfilled ? ' (backfill)' : ''}`);
                     }
                 } catch (error) {
-                    console.error(`[${accountId}] FT transfers sync failed:`, error);
+                    console.error(`[${accountId}] Transfers sync failed:`, error);
                 }
 
                 // Skip backward search if shutting down

--- a/scripts/fastnear-transfers-api.ts
+++ b/scripts/fastnear-transfers-api.ts
@@ -248,13 +248,22 @@ export async function getAllAccountTransfers(
 
 /**
  * Map a transfers-API asset_id to the V2 BalanceChangeRecord token_id convention:
- *   - "native:near"            -> "near"
- *   - "nep141:<contract>" (Ft) -> "<contract>"   (bare FT contract id)
- * The bare-contract form matches how FT records are stored today; the "nep141:"
- * prefix is reserved for intents internal tokens, which this API does not emit.
+ *   - "native:near"                                  -> "near"
+ *   - "nep141:<contract>"                      (Ft)  -> "<contract>"        (bare FT contract)
+ *   - "nep245:intents.near:nep141:<contract>"  (Mt)  -> "nep141:<contract>" (intents balance)
+ *
+ * Bare-contract ids are how on-chain FT balances are stored; the "nep141:"-
+ * prefixed form is the canonical id for NEAR Intents internal balances (the one
+ * the app/frontend resolves metadata for). For intents multi-tokens the API uses
+ * the longer "nep245:intents.near:<inner>" id, so we strip the intents-contract
+ * prefix down to that inner id.
  */
 export function assetIdToTokenId(assetId: string, assetType?: string): string {
     if (assetId === 'native:near' || assetType === 'Native') return 'near';
+    // NEAR Intents multi-token: nep245:intents.near:nep141:X -> nep141:X
+    const intentsPrefix = 'nep245:intents.near:';
+    if (assetId.startsWith(intentsPrefix)) return assetId.slice(intentsPrefix.length);
+    // Bare NEP-141 fungible token: nep141:X -> X
     if (assetId.startsWith('nep141:')) return assetId.slice('nep141:'.length);
     return assetId;
 }

--- a/scripts/transfers-sync.ts
+++ b/scripts/transfers-sync.ts
@@ -1,18 +1,19 @@
-// FT transfer sync — makes the FastNear Transfers API the authoritative source
-// for fungible-token (NEP-141) balance-change records.
+// Transfers sync — makes the FastNear Transfers API the authoritative source for
+// fungible-token (NEP-141) AND NEAR Intents (NEP-245) balance-change records.
 //
 // Background: the legacy pipeline discovers a *transaction* block N and samples
-// ft_balance_of at N and N+1. Multi-hop claims (e.g. distribution.nearmobile.near
-// → npro.nearmobile.near) settle the credit at N+2, outside that window, so the
-// transfer is dropped and the claim is invisible. The transfers API reports each
-// transfer at its real receipt block with authoritative start/end-of-block
-// balances, eliminating the guesswork.
+// balances at N and N+1. Multi-hop transfers settle a couple blocks later, outside
+// that window, so they're dropped — e.g. NPRO claims (distribution.nearmobile.near
+// → npro.nearmobile.near, credited at N+2) and intents deposits (ft_transfer_call
+// → intents.near, credited via ft_on_transfer at N+2). The transfers API reports
+// every transfer at its real receipt block with authoritative start/end-of-block
+// balances, eliminating the guesswork — FT as asset_type "Ft", intents as "Mt".
 //
-// Scope: this module owns FT records only. NEAR (token_id "near") stays on the
-// existing path (the transfers API does not surface gas/implicit balance
-// movements, so switching NEAR wholesale would lose data). Intents internal
-// tokens ("nep141:*") and staking pools ("*.poolv1.near", ...) keep their
-// dedicated discovery paths.
+// Scope: this module owns FT records (bare contract ids) and intents records
+// (canonical "nep141:<contract>"). NEAR (token_id "near") stays on the existing
+// path — the transfers API doesn't surface gas/implicit movements, so switching
+// NEAR wholesale would lose data. Staking pools ("*.poolv1.near", ...) keep their
+// dedicated discovery path.
 
 import fs from 'fs';
 import {
@@ -28,20 +29,33 @@ import {
 } from './fastnear-transfers-api.js';
 
 /**
- * Does this token_id belong to the transfers-API-owned FT space?
- *
- * Owns only bare NEP-141 contract ids (e.g. "npro.nearmobile.near"). Excludes:
- *  - NEAR ("near")
- *  - intents / multi-token ids, which are scheme-prefixed and therefore contain
- *    a colon ("nep141:...", "nep245:intents.near:nep141:..."). A real NEAR
- *    account id never contains ":", so this one check covers every intents form.
- *  - staking pools ("*.poolv1.near", ...)
+ * A bare on-chain NEP-141 fungible token (e.g. "npro.nearmobile.near").
+ * Excludes NEAR, scheme-prefixed intents ids (they contain ":"), and staking pools.
  */
 export function isFtToken(tokenId: string): boolean {
     if (tokenId === 'near') return false;
     if (tokenId.includes(':')) return false; // intents / scheme-prefixed multi-token
     if (isStakingPool(tokenId)) return false;
     return true;
+}
+
+/**
+ * A NEAR Intents internal balance. Canonical form is "nep141:<contract>"; older
+ * records may use the longer "nep245:intents.near:nep141:<contract>" form, which
+ * the backfill rewrites to the canonical id.
+ */
+export function isIntentsToken(tokenId: string): boolean {
+    return tokenId.startsWith('nep141:') || tokenId.startsWith('nep245:intents.near:');
+}
+
+/**
+ * Tokens owned by the transfers-API sync: bare FT contracts AND NEAR Intents
+ * balances. Both have a complete, authoritative ledger in the transfers API
+ * (FT as asset_type "Ft", intents as "Mt"). NEAR and staking pools are NOT owned
+ * and keep their existing discovery paths.
+ */
+export function isTransfersOwned(tokenId: string): boolean {
+    return isFtToken(tokenId) || isIntentsToken(tokenId);
 }
 
 /** Stable identity for an FT record so the authoritative version replaces a stale one. */
@@ -75,16 +89,24 @@ export const syntheticGapSampler: GapSampler = async (gap: TokenGap) => {
 };
 
 export interface MergeOptions {
-    /** Replace ALL existing FT records instead of appending after the latest. */
-    fullResync?: boolean;
+    /**
+     * Backfill mode: the `fetched` set is the FULL history, so decide per token
+     * whether the API ledger is authoritative. A token whose API ledger is
+     * internally continuous replaces the existing records for that token; a token
+     * whose API ledger has gaps (swap-heavy intents tokens settle several
+     * transfers per block, so the API's per-transfer balances don't chain) is
+     * left as-is to avoid regressing it. Without this flag the merge is
+     * incremental (additive, existing-wins).
+     */
+    backfill?: boolean;
     /** Reconcile per-token balance discontinuities. Defaults to syntheticGapSampler. */
     sampler?: GapSampler;
 }
 
 export interface MergeResult {
-    /** Full merged record set across all tokens (FT replaced, others untouched). */
+    /** Full merged record set across all tokens (owned merged, others untouched). */
     records: BalanceChangeRecord[];
-    /** Number of FT records fetched from the transfers API. */
+    /** Number of owned (FT + intents) records fetched from the transfers API. */
     fetched: number;
     /** Discontinuities detected after merging. */
     gaps: TokenGap[];
@@ -92,14 +114,35 @@ export interface MergeResult {
     filled: number;
 }
 
+function groupByToken(records: BalanceChangeRecord[]): Map<string, BalanceChangeRecord[]> {
+    const m = new Map<string, BalanceChangeRecord[]>();
+    for (const r of records) {
+        const list = m.get(r.token_id) || [];
+        list.push(r);
+        m.set(r.token_id, list);
+    }
+    return m;
+}
+
 /**
  * Pure merge: combine existing records with freshly fetched transfer records.
  *
- * - Non-FT records (NEAR, intents, staking) pass through untouched.
- * - FT records: in incremental mode the existing set is kept and new records are
- *   added (authoritative version wins on key collision). In fullResync mode the
- *   existing FT set is discarded and rebuilt from the fetched records.
- * - After merging, per-token continuity is checked and any gap is reconciled.
+ * Non-owned records (NEAR, staking) always pass through untouched. For owned
+ * tokens (FT + intents):
+ *
+ *  - Incremental (default): keep every existing record and ADD only genuinely
+ *    new transfers (existing wins on key collision). The legacy balance-change
+ *    tracker records single-block settlements (incl. wNEAR/bridge mint & burn,
+ *    which aren't transfers); this preserves them and just adds the multi-hop
+ *    transfers it drops (FT claims, intents deposits).
+ *
+ *  - Backfill: per token, if the API's full ledger is internally continuous it
+ *    is authoritative and replaces the existing records for that token; if it has
+ *    gaps (swap-heavy intents tokens), the existing records are kept so we never
+ *    regress a token. New tokens (no existing records) take the API ledger.
+ *
+ * After merging, per-token continuity is checked and any residual gap is
+ * reconciled by the sampler.
  */
 export async function mergeFtTransferRecords(
     existing: BalanceChangeRecord[],
@@ -108,53 +151,70 @@ export async function mergeFtTransferRecords(
 ): Promise<MergeResult> {
     const sampler = opts.sampler ?? syntheticGapSampler;
 
-    const ftFetched = fetched.filter(r => isFtToken(r.token_id));
-    const ftExisting = existing.filter(r => isFtToken(r.token_id));
-    const nonFt = existing.filter(r => !isFtToken(r.token_id));
+    const ownedFetched = fetched.filter(r => isTransfersOwned(r.token_id));
+    const ownedExisting = existing.filter(r => isTransfersOwned(r.token_id));
+    const nonOwned = existing.filter(r => !isTransfersOwned(r.token_id));
 
-    const base = opts.fullResync ? [] : ftExisting;
+    let merged: BalanceChangeRecord[];
 
-    // Build the FT set, existing-wins. The legacy balance-change tracker's FT
-    // records are correct but INCOMPLETE: it captures single-block settlements
-    // (incl. wNEAR/bridge mint & burn, which aren't transfers) but drops 2+ hop
-    // claims that settle outside its sampling window. So we keep every existing
-    // record and let the transfers API ADD only the genuinely-missing transfers
-    // (matched by receipt id). Existing is inserted last so it wins collisions —
-    // this preserves mint/burn context instead of overwriting it.
-    const dedup = new Map<string, BalanceChangeRecord>();
-    for (const r of ftFetched) dedup.set(ftKey(r), r);
-    for (const r of base) dedup.set(ftKey(r), r);
-    let merged = [...dedup.values()];
+    if (opts.backfill) {
+        // Per-token: adopt the API ledger only when it is internally continuous.
+        const fByTok = groupByToken(ownedFetched);
+        const eByTok = groupByToken(ownedExisting);
+        const tokens = new Set<string>([...fByTok.keys(), ...eByTok.keys()]);
+        merged = [];
+        for (const tok of tokens) {
+            const cand = (fByTok.get(tok) || []).slice().sort((a, b) => a.block_height - b.block_height);
+            const ex = eByTok.get(tok) || [];
+            if (cand.length > 0 && detectTokenGaps(cand).length === 0) {
+                merged.push(...cand);          // API ledger complete -> authoritative
+            } else if (ex.length > 0) {
+                merged.push(...ex);            // API incomplete -> keep existing (no regression)
+            } else {
+                merged.push(...cand);          // new token, best effort (sampler fills residual)
+            }
+        }
+    } else {
+        // Incremental, existing-wins: add only genuinely-missing transfers.
+        const dedup = new Map<string, BalanceChangeRecord>();
+        for (const r of ownedFetched) dedup.set(ftKey(r), r);
+        for (const r of ownedExisting) dedup.set(ftKey(r), r);
+        merged = [...dedup.values()];
+    }
 
     const gaps = detectTokenGaps(merged);
     let filled = 0;
     if (gaps.length > 0) {
+        const byKey = new Map<string, BalanceChangeRecord>();
+        for (const r of merged) byKey.set(ftKey(r), r);
         for (const gap of gaps) {
             const recovered = await sampler(gap);
             for (const r of recovered) {
-                dedup.set(ftKey(r), r);
+                byKey.set(ftKey(r), r);
                 filled++;
             }
         }
-        merged = [...dedup.values()];
+        merged = [...byKey.values()];
     }
 
-    const records = [...nonFt, ...merged].sort((a, b) => b.block_height - a.block_height);
-    return { records, fetched: ftFetched.length, gaps, filled };
+    const records = [...nonOwned, ...merged].sort((a, b) => b.block_height - a.block_height);
+    return { records, fetched: ownedFetched.length, gaps, filled };
 }
 
-/** Highest FT-record block currently stored (0 if none). */
-export function latestFtBlock(records: BalanceChangeRecord[]): number {
+/** Highest block among transfers-API-owned records (FT + intents); 0 if none. */
+export function latestOwnedBlock(records: BalanceChangeRecord[]): number {
     let max = 0;
     for (const r of records) {
-        if (isFtToken(r.token_id) && r.block_height > max) max = r.block_height;
+        if (isTransfersOwned(r.token_id) && r.block_height > max) max = r.block_height;
     }
     return max;
 }
 
-// Bumped when the FT-record semantics change in a way that requires a one-time
-// full re-fetch to backfill/correct existing files (e.g. the N+2 claim fix).
-export const FT_BACKFILL_VERSION = 1;
+// Bumped when the owned-record semantics change in a way that requires a one-time
+// full re-fetch to backfill/correct existing files.
+//   1: initial FT (NEP-141) ingestion (N+2 claim fix)
+//   2: + NEAR Intents balances (NEP-245 "Mt"), normalized to canonical nep141:X
+export const FT_BACKFILL_VERSION = 2;
 
 export interface SyncOptions extends MergeOptions {
     /** Injectable fetcher for tests; defaults to the live transfers API. */
@@ -176,11 +236,12 @@ export interface SyncResult extends MergeResult {
 }
 
 /**
- * Sync FT transfer records for one account into its V2 history file.
+ * Sync transfers-API records (FT + NEAR Intents) for one account into its V2
+ * history file.
  *
- * Reads the file, fetches FT transfers from the transfers API (incrementally
- * after the latest stored FT block, or the full history on fullResync), merges,
- * reconciles gaps, and writes back. Non-V2 files are skipped.
+ * Reads the file, fetches transfers from the API (incrementally after the latest
+ * stored owned block, or the full history on backfill), merges, reconciles gaps,
+ * and writes back. Non-V2 files are skipped.
  */
 export async function syncFtTransfersForAccount(
     accountId: string,
@@ -195,35 +256,34 @@ export async function syncFtTransfersForAccount(
 
     const data = JSON.parse(fs.readFileSync(outputFile, 'utf-8'));
     if (data.version !== 2 || !Array.isArray(data.records)) {
-        // FT sync operates on the flat V2 format only.
+        // Sync operates on the flat V2 format only.
         return { records: data.records ?? [], fetched: 0, gaps: [], filled: 0, afterBlock: 0, changed: false, backfilled: false };
     }
 
     const existing: BalanceChangeRecord[] = data.records;
     data.metadata = data.metadata || {};
 
-    // Two-phase sync:
+    // Two-phase sync (applies to owned tokens: FT + NEAR Intents balances):
     //
-    //  - One-time backfill (file predates FT_BACKFILL_VERSION): rebuild the FT
-    //    set cleanly from the authoritative transfers API (full fetch + discard).
-    //    The legacy FT records and the transfers API keep balances on different
-    //    bases, so blanket-merging the two produces spurious discontinuities;
-    //    a clean rebuild avoids that. The only records lost are historical
-    //    mint/burn (wNEAR/bridge), which aren't transfers — the continuity check
-    //    re-creates them synthetically with correct amounts/balances.
+    //  - One-time backfill (file predates FT_BACKFILL_VERSION): fetch the FULL
+    //    history and, per token, adopt the API ledger where it is internally
+    //    continuous (authoritative, normalized to canonical ids) while leaving
+    //    tokens the API can't represent cleanly (swap-heavy intents) as-is. This
+    //    recovers the dropped transfers without regressing any token.
     //
-    //  - Steady state (incremental): fetch after the latest stored FT block and
+    //  - Steady state (incremental): fetch after the latest stored owned block and
     //    merge ADDITIVELY (existing-wins). The balance-change tracker runs first
     //    each cycle and records new mint/burn with full tx context; this keeps
-    //    them and only adds the multi-hop claims the tracker still misses.
+    //    them and only adds the multi-hop transfers the tracker misses (FT claims,
+    //    intents deposits).
     //
-    // Non-FT records (NEAR, intents, staking) are never touched.
+    // NEAR and staking records are never touched.
     const needsBackfill = data.metadata.ftBackfillVersion !== FT_BACKFILL_VERSION;
-    const fullResync = opts.fullResync || needsBackfill;
-    const afterBlock = fullResync ? 0 : latestFtBlock(existing);
+    const backfill = needsBackfill || opts.backfill === true;
+    const afterBlock = backfill ? 0 : latestOwnedBlock(existing);
 
     const fetched = await fetchRecords(accountId, { afterBlock: afterBlock || undefined });
-    const result = await mergeFtTransferRecords(existing, fetched, { ...opts, fullResync });
+    const result = await mergeFtTransferRecords(existing, fetched, { ...opts, backfill });
 
     const changed =
         result.records.length !== existing.length ||

--- a/test/integration/fastnear-transfers-api.test.ts
+++ b/test/integration/fastnear-transfers-api.test.ts
@@ -93,4 +93,27 @@ describe('FastNear Transfers API (live)', function () {
             `Expected no balance discontinuities in transfers-derived NPRO records, got: ${JSON.stringify(gaps)}`
         );
     });
+
+    it('captures NEAR Intents NPRO deposits as a continuous nep141: ledger', async function () {
+        // The intents side (asset_type "Mt") carries the deposits into NEAR
+        // Intents that the legacy path dropped. They must map to the canonical
+        // nep141:<contract> token_id and form a continuous, deposit-bearing ledger.
+        const records = await getAccountTransferRecords(ACCOUNT, {
+            assetId: 'nep245:intents.near:nep141:npro.nearmobile.near',
+            fromTimestampMs: FROM_MS,
+            toTimestampMs: TO_MS,
+        });
+
+        const intents = records.filter(r => r.token_id === 'nep141:npro.nearmobile.near');
+        assert.ok(intents.length >= 2, 'Expected intents NPRO records mapped to nep141: form');
+
+        const deposits = intents.filter(r => BigInt(r.amount) > 0n);
+        assert.ok(deposits.length > 0, 'Expected at least one intents NPRO deposit');
+
+        assert.deepEqual(
+            detectTokenGaps(intents),
+            [],
+            'Intents NPRO ledger from the API should be internally continuous'
+        );
+    });
 });

--- a/test/unit/fastnear-transfers-api.test.ts
+++ b/test/unit/fastnear-transfers-api.test.ts
@@ -50,6 +50,17 @@ describe('assetIdToTokenId', function () {
             'usdt.tether-token.near'
         );
     });
+
+    it('maps intents (Mt) multi-token ids to the canonical nep141: form', () => {
+        assert.equal(
+            assetIdToTokenId('nep245:intents.near:nep141:npro.nearmobile.near', 'Mt'),
+            'nep141:npro.nearmobile.near'
+        );
+        assert.equal(
+            assetIdToTokenId('nep245:intents.near:nep141:wrap.near', 'Mt'),
+            'nep141:wrap.near'
+        );
+    });
 });
 
 describe('mapTransferToRecord', function () {

--- a/test/unit/transfers-sync.test.ts
+++ b/test/unit/transfers-sync.test.ts
@@ -5,7 +5,9 @@ import os from 'os';
 import path from 'path';
 import {
     isFtToken,
-    latestFtBlock,
+    isIntentsToken,
+    isTransfersOwned,
+    latestOwnedBlock,
     mergeFtTransferRecords,
     syntheticGapSampler,
     syncFtTransfersForAccount,
@@ -29,36 +31,50 @@ function rec(partial: Partial<BalanceChangeRecord> & { token_id: string; block_h
     };
 }
 
-describe('isFtToken', function () {
-    it('owns plain FT contracts, not NEAR / intents / staking', () => {
+describe('token classification', function () {
+    it('isFtToken: plain FT contracts only', () => {
         assert.equal(isFtToken('npro.nearmobile.near'), true);
         assert.equal(isFtToken('usdt.tether-token.near'), true);
         assert.equal(isFtToken('near'), false);
-        assert.equal(isFtToken('nep141:npro.nearmobile.near'), false); // intents internal
+        assert.equal(isFtToken('nep141:npro.nearmobile.near'), false); // intents
         assert.equal(isFtToken('npro.poolv1.near'), false);            // staking pool
-        assert.equal(isFtToken('binancenode1.poolv1.near'), false);
+    });
+
+    it('isIntentsToken: nep141:/nep245:intents.near: ids', () => {
+        assert.equal(isIntentsToken('nep141:npro.nearmobile.near'), true);
+        assert.equal(isIntentsToken('nep245:intents.near:nep141:wrap.near'), true);
+        assert.equal(isIntentsToken('npro.nearmobile.near'), false);
+        assert.equal(isIntentsToken('near'), false);
+    });
+
+    it('isTransfersOwned: FT + intents, not NEAR / staking', () => {
+        assert.equal(isTransfersOwned('npro.nearmobile.near'), true);       // FT
+        assert.equal(isTransfersOwned('nep141:npro.nearmobile.near'), true); // intents
+        assert.equal(isTransfersOwned('nep245:intents.near:nep141:wrap.near'), true);
+        assert.equal(isTransfersOwned('near'), false);
+        assert.equal(isTransfersOwned('binancenode1.poolv1.near'), false);
     });
 });
 
-describe('latestFtBlock', function () {
-    it('returns the max block among FT records only', () => {
+describe('latestOwnedBlock', function () {
+    it('returns the max block among owned (FT + intents) records', () => {
         const records = [
             rec({ token_id: 'npro.nearmobile.near', block_height: 100 }),
             rec({ token_id: 'near', block_height: 999 }),               // ignored
-            rec({ token_id: 'npro.poolv1.near', block_height: 888 }),   // ignored
-            rec({ token_id: 'npro.nearmobile.near', block_height: 200 }),
+            rec({ token_id: 'npro.poolv1.near', block_height: 888 }),   // ignored (staking)
+            rec({ token_id: 'nep141:npro.nearmobile.near', block_height: 300 }), // intents counted
         ];
-        assert.equal(latestFtBlock(records), 200);
-        assert.equal(latestFtBlock([]), 0);
+        assert.equal(latestOwnedBlock(records), 300);
+        assert.equal(latestOwnedBlock([]), 0);
     });
 });
 
 describe('mergeFtTransferRecords', function () {
-    it('appends new FT records and leaves NEAR/intents/staking untouched', async () => {
+    it('appends new owned records and leaves NEAR/staking untouched', async () => {
         const existing = [
             rec({ token_id: 'near', block_height: 50, amount: '-1' }),
-            rec({ token_id: 'nep141:npro.nearmobile.near', block_height: 60 }),
-            rec({ token_id: 'binancenode1.poolv1.near', block_height: 70 }),
+            rec({ token_id: 'nep141:npro.nearmobile.near', block_height: 60 }), // intents (owned)
+            rec({ token_id: 'binancenode1.poolv1.near', block_height: 70 }),    // staking (not owned)
             rec({ token_id: 'npro.nearmobile.near', block_height: 100, receipt_id: 'A', amount: '10', balance_before: '0', balance_after: '10' }),
         ];
         const fetched = [
@@ -67,13 +83,29 @@ describe('mergeFtTransferRecords', function () {
         const result = await mergeFtTransferRecords(existing, fetched);
         assert.equal(result.fetched, 1);
         assert.equal(result.gaps.length, 0);
-        // All non-FT preserved, plus both FT records.
         assert.equal(result.records.length, 5);
-        assert.ok(result.records.some(r => r.token_id === 'near'));
-        assert.ok(result.records.some(r => r.token_id === 'nep141:npro.nearmobile.near'));
-        assert.ok(result.records.some(r => r.token_id === 'binancenode1.poolv1.near'));
-        // Sorted newest-first.
+        assert.ok(result.records.some(r => r.token_id === 'near'));                       // NEAR untouched
+        assert.ok(result.records.some(r => r.token_id === 'nep141:npro.nearmobile.near')); // intents preserved
+        assert.ok(result.records.some(r => r.token_id === 'binancenode1.poolv1.near'));   // staking untouched
         assert.deepEqual(result.records.map(r => r.block_height), [200, 100, 70, 60, 50]);
+    });
+
+    it('adds a missing INTENTS deposit (the user-reported gap)', async () => {
+        // Production shape: the intents withdrawal/swap was recorded (balance
+        // jumps to a full amount from dust) but the deposit that funded it was
+        // dropped — a per-token discontinuity. The transfers API supplies the
+        // missing ft_on_transfer deposit, restoring continuity.
+        const existing = [
+            rec({ token_id: 'nep141:npro.nearmobile.near', block_height: 500, receipt_id: 'SWAP', amount: '-24', balance_before: '24', balance_after: '0' }),
+        ];
+        const fetched = [
+            rec({ token_id: 'nep141:npro.nearmobile.near', block_height: 480, receipt_id: 'DEPOSIT', amount: '24', balance_before: '0', balance_after: '24' }),
+        ];
+        const result = await mergeFtTransferRecords(existing, fetched);
+        const intents = result.records.filter(r => r.token_id === 'nep141:npro.nearmobile.near');
+        assert.equal(result.fetched, 1, 'intents transfer is owned and ingested');
+        assert.equal(intents.length, 2, 'deposit added alongside the existing swap');
+        assert.equal(result.gaps.length, 0, 'deposit restores intents continuity');
     });
 
     it('keeps the existing record on a receipt collision (existing-wins, no duplicate)', async () => {
@@ -124,18 +156,37 @@ describe('mergeFtTransferRecords', function () {
         assert.equal(synthetic!.balance_after, '50');
     });
 
-    it('fullResync discards the existing FT set and rebuilds from fetched', async () => {
+    it('backfill: adopts a clean API ledger per token, keeps NEAR untouched', async () => {
         const existing = [
-            rec({ token_id: 'old.near', block_height: 1, receipt_id: 'X', amount: '1', balance_after: '1' }),
+            // stale/incomplete existing FT records for tkn.near (will be replaced)
+            rec({ token_id: 'tkn.near', block_height: 1, receipt_id: 'OLD', amount: '1', balance_before: '0', balance_after: '1' }),
             rec({ token_id: 'near', block_height: 2, amount: '-1' }),
         ];
         const fetched = [
-            rec({ token_id: 'new.near', block_height: 300, receipt_id: 'Y', amount: '7', balance_after: '7' }),
+            rec({ token_id: 'tkn.near', block_height: 100, receipt_id: 'A', amount: '10', balance_before: '0', balance_after: '10' }),
+            rec({ token_id: 'tkn.near', block_height: 200, receipt_id: 'B', amount: '5', balance_before: '10', balance_after: '15' }),
         ];
-        const result = await mergeFtTransferRecords(existing, fetched, { fullResync: true });
-        assert.ok(!result.records.some(r => r.token_id === 'old.near'), 'old FT record dropped on full resync');
-        assert.ok(result.records.some(r => r.token_id === 'near'), 'NEAR record preserved even on full resync');
-        assert.ok(result.records.some(r => r.token_id === 'new.near'));
+        const result = await mergeFtTransferRecords(existing, fetched, { backfill: true });
+        const tkn = result.records.filter(r => r.token_id === 'tkn.near');
+        assert.equal(tkn.length, 2, 'clean API ledger replaces the stale existing records');
+        assert.ok(!result.records.some(r => r.receipt_id === 'OLD'), 'stale record dropped');
+        assert.ok(result.records.some(r => r.token_id === 'near'), 'NEAR untouched');
+        assert.equal(result.gaps.length, 0);
+    });
+
+    it('backfill: keeps existing records for a token whose API ledger is gappy (no regression)', async () => {
+        const existing = [
+            rec({ token_id: 'swap.near', block_height: 10, receipt_id: 'E1', amount: '5', balance_before: '0', balance_after: '5' }),
+            rec({ token_id: 'swap.near', block_height: 20, receipt_id: 'E2', amount: '5', balance_before: '5', balance_after: '10' }),
+        ];
+        // API ledger for swap.near is internally discontinuous (5 -> 99).
+        const fetched = [
+            rec({ token_id: 'swap.near', block_height: 11, receipt_id: 'F1', amount: '5', balance_before: '0', balance_after: '5' }),
+            rec({ token_id: 'swap.near', block_height: 21, receipt_id: 'F2', amount: '5', balance_before: '99', balance_after: '104' }),
+        ];
+        const result = await mergeFtTransferRecords(existing, fetched, { backfill: true });
+        const swap = result.records.filter(r => r.token_id === 'swap.near');
+        assert.deepEqual(swap.map(r => r.receipt_id).sort(), ['E1', 'E2'], 'kept existing, did not adopt gappy API ledger');
     });
 });
 
@@ -186,7 +237,7 @@ describe('syncFtTransfersForAccount', function () {
         assert.ok(!written.records.some((r: any) => r.receipt_id === 'STALE'), 'stale FT record dropped');
         assert.ok(written.records.some((r: any) => r.receipt_id === 'REAL'));
         assert.ok(written.records.some((r: any) => r.token_id === 'near'));
-        assert.equal(written.metadata.ftBackfillVersion, 1);
+        assert.equal(written.metadata.ftBackfillVersion, 2);
 
         fs.rmSync(dir, { recursive: true, force: true });
     });
@@ -200,7 +251,7 @@ describe('syncFtTransfersForAccount', function () {
             records: [
                 rec({ token_id: 'npro.nearmobile.near', block_height: 100, receipt_id: 'A', amount: '10', balance_after: '10' }),
             ],
-            metadata: { firstBlock: 100, lastBlock: 100, totalRecords: 1, ftBackfillVersion: 1 },
+            metadata: { firstBlock: 100, lastBlock: 100, totalRecords: 1, ftBackfillVersion: 2 },
         }, null, 2));
 
         let calledAfter: number | undefined = -1;


### PR DESCRIPTION
## Problem

Daily NPRO moved into NEAR Intents wasn't showing the **deposits**. Depositing via `ft_transfer_call` to `intents.near` is multi-hop — intents credits the internal NEP-245 balance ~2 blocks later, outside the legacy N/N+1 sampling window — so the deposit was dropped. In production the intents NPRO ledger had only **7 of ~34 May deposits** and **32 continuity gaps**.

## Fix

The FastNear Transfers API already returns these as `asset_type: "Mt"` (`asset_id: "nep245:intents.near:nep141:<contract>"`) — the FT-scoped filter from #46 was discarding them. This extends the sync to own intents balances:

- **`assetIdToTokenId`**: map `Mt` ids to the canonical `nep141:<contract>` form the app/frontend resolves metadata for (also repairs stale `nep245:intents.near:...` ids).
- **`isIntentsToken` / `isTransfersOwned`**: own FT (bare ids) **and** intents (`nep141:` / `nep245:intents.near:`). NEAR and staking pools keep their existing paths.
- **Backfill is now per-token adopt-if-clean**: a token whose API ledger is internally continuous is rebuilt from it (authoritative, normalized); a token whose API ledger is gappy — swap-heavy intents tokens settle several transfers per block via `execute_intents`, so the API's per-transfer balances don't chain — is left as-is. **No token regresses.** Incremental stays additive (existing-wins).
- Bump `FT_BACKFILL_VERSION` → 2 to re-trigger the one-time backfill.

## Validation (live production data, `petersalomonsen.near`)

| | before (v1) | after (v2) |
|---|---|---|
| intents NPRO deposits | 7 | **48** (all 34 May days) |
| total owned continuity gaps | 70 | **1** (pre-existing wNEAR same-block mint) |
| FT claims | 67 | 67 (unchanged) |
| NEAR / staking records | — | untouched |

Tests: 119 unit + 4 live integration passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)