### PR TITLE
Stop synthesizing gap records; purge existing ones on re-backfill

### DIFF
--- a/scripts/transfers-sync.ts
+++ b/scripts/transfers-sync.ts
@@ -64,6 +64,16 @@ function ftKey(r: BalanceChangeRecord): string {
 }
 
 /**
+ * A record this module previously synthesized to bridge a gap: it has no tx,
+ * receipt, or timestamp. Used to purge such records on re-backfill. (Owned FT/
+ * intents records from the API always carry a tx hash and timestamp, so this
+ * never matches real transfer records.)
+ */
+function isSynthetic(r: BalanceChangeRecord): boolean {
+    return r.block_timestamp == null && r.receipt_id == null && r.tx_hash == null;
+}
+
+/**
  * Default gap reconciler. The transfers API balances already tell us the true
  * balance on both sides of a discontinuity, so we synthesize a single record
  * that reconnects them (amount = the diff). No RPC sampling required; a richer
@@ -99,7 +109,11 @@ export interface MergeOptions {
      * incremental (additive, existing-wins).
      */
     backfill?: boolean;
-    /** Reconcile per-token balance discontinuities. Defaults to syntheticGapSampler. */
+    /**
+     * Optional gap reconciler. If provided, per-token balance discontinuities are
+     * filled by this sampler. Off by default — production does not synthesize
+     * records (see syntheticGapSampler, kept for experiments/tests).
+     */
     sampler?: GapSampler;
 }
 
@@ -149,10 +163,17 @@ export async function mergeFtTransferRecords(
     fetched: BalanceChangeRecord[],
     opts: MergeOptions = {}
 ): Promise<MergeResult> {
-    const sampler = opts.sampler ?? syntheticGapSampler;
+    // Gap reconciliation is opt-in. By default we do NOT synthesize records:
+    // the per-token backfill already keeps each token on a single coherent
+    // source, and synthetic records (no tx/receipt/timestamp) are low value and
+    // caused downstream issues (null block_timestamp). Pass opts.sampler to
+    // re-enable, e.g. for experiments.
+    const sampler = opts.sampler;
 
     const ownedFetched = fetched.filter(r => isTransfersOwned(r.token_id));
-    const ownedExisting = existing.filter(r => isTransfersOwned(r.token_id));
+    // Drop previously-synthesized records (null timestamp marker) so a re-backfill
+    // cleans them out instead of carrying them forward.
+    const ownedExisting = existing.filter(r => isTransfersOwned(r.token_id) && !isSynthetic(r));
     const nonOwned = existing.filter(r => !isTransfersOwned(r.token_id));
 
     let merged: BalanceChangeRecord[];
@@ -171,7 +192,7 @@ export async function mergeFtTransferRecords(
             } else if (ex.length > 0) {
                 merged.push(...ex);            // API incomplete -> keep existing (no regression)
             } else {
-                merged.push(...cand);          // new token, best effort (sampler fills residual)
+                merged.push(...cand);          // new token, best effort
             }
         }
     } else {
@@ -184,7 +205,7 @@ export async function mergeFtTransferRecords(
 
     const gaps = detectTokenGaps(merged);
     let filled = 0;
-    if (gaps.length > 0) {
+    if (gaps.length > 0 && sampler) {
         const byKey = new Map<string, BalanceChangeRecord>();
         for (const r of merged) byKey.set(ftKey(r), r);
         for (const gap of gaps) {
@@ -214,7 +235,8 @@ export function latestOwnedBlock(records: BalanceChangeRecord[]): number {
 // full re-fetch to backfill/correct existing files.
 //   1: initial FT (NEP-141) ingestion (N+2 claim fix)
 //   2: + NEAR Intents balances (NEP-245 "Mt"), normalized to canonical nep141:X
-export const FT_BACKFILL_VERSION = 2;
+//   3: purge synthetic gap records (null timestamp); gap reconciliation now opt-in
+export const FT_BACKFILL_VERSION = 3;
 
 export interface SyncOptions extends MergeOptions {
     /** Injectable fetcher for tests; defaults to the live transfers API. */

--- a/test/unit/transfers-sync.test.ts
+++ b/test/unit/transfers-sync.test.ts
@@ -16,8 +16,9 @@ import type { BalanceChangeRecord } from '../../scripts/balance-tracker.js';
 
 function rec(partial: Partial<BalanceChangeRecord> & { token_id: string; block_height: number }): BalanceChangeRecord {
     return {
-        block_timestamp: null,
-        tx_hash: null,
+        // Real records carry a timestamp; tests that want a synthetic record set it null.
+        block_timestamp: '2026-01-01T00:00:00.000Z',
+        tx_hash: 'tx',
         tx_block: null,
         signer_id: null,
         receiver_id: null,
@@ -140,14 +141,19 @@ describe('mergeFtTransferRecords', function () {
         assert.equal(result.gaps.length, 0, 'added claim restores continuity');
     });
 
-    it('reconciles a real discontinuity with the synthetic sampler', async () => {
+    it('reconciles a real discontinuity when a sampler is provided (opt-in)', async () => {
         const existing: BalanceChangeRecord[] = [];
         const fetched = [
             rec({ token_id: 'tkn.near', block_height: 100, receipt_id: 'A', amount: '10', balance_before: '0', balance_after: '10' }),
             // jump: balance_before 50 != previous balance_after 10 -> missing transfer
             rec({ token_id: 'tkn.near', block_height: 200, receipt_id: 'B', amount: '5', balance_before: '50', balance_after: '55' }),
         ];
-        const result = await mergeFtTransferRecords(existing, fetched);
+        // Without a sampler, gaps are reported but not filled.
+        const noFill = await mergeFtTransferRecords(existing, fetched);
+        assert.equal(noFill.gaps.length, 1);
+        assert.equal(noFill.filled, 0);
+        // Opt in to the synthetic sampler.
+        const result = await mergeFtTransferRecords(existing, fetched, { sampler: syntheticGapSampler });
         assert.equal(result.gaps.length, 1);
         assert.equal(result.filled, 1);
         const synthetic = result.records.find(r => r.amount === '40');
@@ -237,7 +243,7 @@ describe('syncFtTransfersForAccount', function () {
         assert.ok(!written.records.some((r: any) => r.receipt_id === 'STALE'), 'stale FT record dropped');
         assert.ok(written.records.some((r: any) => r.receipt_id === 'REAL'));
         assert.ok(written.records.some((r: any) => r.token_id === 'near'));
-        assert.equal(written.metadata.ftBackfillVersion, 2);
+        assert.equal(written.metadata.ftBackfillVersion, 3);
 
         fs.rmSync(dir, { recursive: true, force: true });
     });
@@ -251,7 +257,7 @@ describe('syncFtTransfersForAccount', function () {
             records: [
                 rec({ token_id: 'npro.nearmobile.near', block_height: 100, receipt_id: 'A', amount: '10', balance_after: '10' }),
             ],
-            metadata: { firstBlock: 100, lastBlock: 100, totalRecords: 1, ftBackfillVersion: 2 },
+            metadata: { firstBlock: 100, lastBlock: 100, totalRecords: 1, ftBackfillVersion: 3 },
         }, null, 2));
 
         let calledAfter: number | undefined = -1;


### PR DESCRIPTION
## Problem

Clicking **load from server** in the app crashed with `TypeError: Cannot read properties of null (reading 'toString')`. Cause: the synthetic gap records introduced in #46/#47 to bridge balance discontinuities carry a **null `block_timestamp`**, and the frontend converter does `entry.timestamp.toString()`. petersalomonsen.near had 27 such records (from the v2 backfill).

## Fix

With the per-token adopt-if-clean backfill (#47), synthesizing records is unnecessary — each token already stays on a single coherent source.

- Gap reconciliation is now **opt-in** (`opts.sampler`); production never synthesizes. `detectTokenGaps` still reports discontinuities for observability.
- Re-backfill **purges** previously-synthesized records (identified by the null timestamp/receipt/tx marker) instead of carrying them forward.
- Bump `FT_BACKFILL_VERSION` → 3 to re-run the one-time backfill.

The companion frontend change makes the converter null-safe for `block_timestamp` (defense in depth).

## Validation (live prod data)

- petersalomonsen.near: 27 synthetic / null-timestamp records → **0** (intents NPRO deposits and FT claims intact).
- Swap-heavy intents tokens whose API ledger is itself discontinuous now show **honest gaps** rather than fabricated null-timestamp records — no crash.

Tests: 119 unit + 4 integration passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)