### PR TITLE
Capture NEAR transfers the balance-tracker drops (fill gaps from API)

### DIFF
--- a/scripts/transfers-sync.ts
+++ b/scripts/transfers-sync.ts
@@ -207,6 +207,11 @@ function fillBlockGapsFromExisting(
  *    new transfers (existing wins on key collision), so the balance-change
  *    tracker's between-backfill records aren't duplicated.
  *
+ * NEAR is handled separately (not "owned"): the balance-tracker stays primary
+ * (it sees gas/staking), and the API's native:near transfers only fill the
+ * tracker's block-level gaps — capturing cross-contract moves it dropped without
+ * displacing the gas/staking records.
+ *
  * After merging, per-token continuity is reported; gap reconciliation is opt-in.
  */
 export async function mergeFtTransferRecords(
@@ -225,7 +230,22 @@ export async function mergeFtTransferRecords(
     // Drop previously-synthesized records (null timestamp marker) so a re-backfill
     // cleans them out instead of carrying them forward.
     const ownedExisting = existing.filter(r => isTransfersOwned(r.token_id) && !isSynthetic(r));
-    const nonOwned = existing.filter(r => !isTransfersOwned(r.token_id));
+
+    // NEAR is NOT owned (the API can't see gas/staking balance moves, so the
+    // balance-tracker stays primary). But the API DOES index explicit native:near
+    // transfers the tracker drops (cross-contract DAO/treasury moves that settle a
+    // couple blocks late). So keep the tracker's NEAR records and fill THEIR
+    // block-level gaps with the API's NEAR transfers — the inverse of owned
+    // tokens. Balances are RPC-verified, and only records inside a real gap are
+    // added, so nothing is double-counted. Residual gas gaps are left as-is.
+    const nearExisting = existing.filter(r => r.token_id === 'near' && !isSynthetic(r));
+    const nearFetched = fetched.filter(r => r.token_id === 'near');
+    const nearFills = fillBlockGapsFromExisting(nearExisting, nearFetched);
+    const nonOwned = [
+        ...existing.filter(r => !isTransfersOwned(r.token_id) && r.token_id !== 'near'),
+        ...nearExisting,
+        ...nearFills,
+    ];
 
     let merged: BalanceChangeRecord[];
 
@@ -282,7 +302,9 @@ export function latestOwnedBlock(records: BalanceChangeRecord[]): number {
 //      over balance continuity) — recovers swap-heavy intents history (wNEAR etc.)
 //   5: backfill also fills the API's block-level gaps with existing balance-tracker
 //      records (captures non-transfer mint/burn the API can't represent)
-export const FT_BACKFILL_VERSION = 5;
+//   6: fill the balance-tracker's NEAR gaps with the API's native:near transfers
+//      (captures cross-contract DAO/treasury moves the tracker drops)
+export const FT_BACKFILL_VERSION = 6;
 
 export interface SyncOptions extends MergeOptions {
     /** Injectable fetcher for tests; defaults to the live transfers API. */

--- a/test/unit/transfers-sync.test.ts
+++ b/test/unit/transfers-sync.test.ts
@@ -91,6 +91,36 @@ describe('mergeFtTransferRecords', function () {
         assert.deepEqual(result.records.map(r => r.block_height), [200, 100, 70, 60, 50]);
     });
 
+    it('fills a NEAR gap with an API native:near transfer the tracker dropped', async () => {
+        // The balance-tracker's NEAR ledger jumps 100 -> 300 between two records:
+        // a cross-contract NEAR transfer (DAO/treasury) it missed. The API has it;
+        // keep the tracker's NEAR records and add the missing transfer in the gap.
+        const existing = [
+            rec({ token_id: 'near', block_height: 100, amount: '-1', balance_before: '101', balance_after: '100' }),
+            rec({ token_id: 'near', block_height: 300, amount: '-1', balance_before: '300', balance_after: '299' }),
+        ];
+        const fetched = [
+            rec({ token_id: 'near', block_height: 200, receipt_id: 'DAO', amount: '200', balance_before: '100', balance_after: '300', counterparty: 'treasury.sputnik-dao.near' }),
+        ];
+        const result = await mergeFtTransferRecords(existing, fetched, { backfill: true });
+        const near = result.records.filter(r => r.token_id === 'near').sort((a, b) => a.block_height - b.block_height);
+        assert.equal(near.length, 3, 'missing NEAR transfer added between the tracker records');
+        assert.equal(near[1]!.receipt_id, 'DAO');
+        assert.equal(result.fetched, 0, 'NEAR is not counted as an owned fetch');
+    });
+
+    it('does not add an API NEAR transfer where the tracker has no gap', async () => {
+        const existing = [
+            rec({ token_id: 'near', block_height: 100, amount: '-1', balance_before: '101', balance_after: '100' }),
+            rec({ token_id: 'near', block_height: 300, amount: '-1', balance_before: '100', balance_after: '99' }),
+        ];
+        const fetched = [
+            rec({ token_id: 'near', block_height: 200, receipt_id: 'DUP', amount: '0', balance_before: '100', balance_after: '100' }),
+        ];
+        const result = await mergeFtTransferRecords(existing, fetched, { backfill: true });
+        assert.ok(!result.records.some(r => r.receipt_id === 'DUP'), 'no gap -> no NEAR fill (no double-count)');
+    });
+
     it('adds a missing INTENTS deposit (the user-reported gap)', async () => {
         // Production shape: the intents withdrawal/swap was recorded (balance
         // jumps to a full amount from dust) but the deposit that funded it was
@@ -260,7 +290,7 @@ describe('syncFtTransfersForAccount', function () {
         assert.ok(!written.records.some((r: any) => r.receipt_id === 'STALE'), 'stale FT record dropped');
         assert.ok(written.records.some((r: any) => r.receipt_id === 'REAL'));
         assert.ok(written.records.some((r: any) => r.token_id === 'near'));
-        assert.equal(written.metadata.ftBackfillVersion, 5);
+        assert.equal(written.metadata.ftBackfillVersion, 6);
 
         fs.rmSync(dir, { recursive: true, force: true });
     });
@@ -274,7 +304,7 @@ describe('syncFtTransfersForAccount', function () {
             records: [
                 rec({ token_id: 'npro.nearmobile.near', block_height: 100, receipt_id: 'A', amount: '10', balance_after: '10' }),
             ],
-            metadata: { firstBlock: 100, lastBlock: 100, totalRecords: 1, ftBackfillVersion: 5 },
+            metadata: { firstBlock: 100, lastBlock: 100, totalRecords: 1, ftBackfillVersion: 6 },
         }, null, 2));
 
         let calledAfter: number | undefined = -1;


### PR DESCRIPTION
## Problem

Cross-contract NEAR transfers — DAO/treasury moves via sputnik-dao — settle a couple blocks after the transaction, outside the balance-tracker's N/N+1 sampling window (the same **N+2 class** as the FT claims). They were missing from the NEAR ledger. On petersalomonsen.near: **323 native:near transfer blocks** present in the FastNear transfers API were absent from the live ledger, including a −200 and a −1000 NEAR treasury move.

## Approach (validated by a shadow run)

Shadow run on the account confirmed:
- **RPC agrees with the API's balances** — NEAR 25/25 and FT 15/15 matched (`start_of_block_balance` == RPC at B−1, `end` == RPC at B). The API is a trustworthy accelerator; RPC stays the authority of record.
- API-seeding surfaces the 323 missing NEAR transfer blocks.

## Change

NEAR remains **not "owned"** (the API can't see gas/staking, so the balance-tracker stays primary). But the API indexes every explicit `native:near` transfer, so we **keep the tracker's NEAR records and fill their block-level gaps with the API's NEAR transfers** — the inverse of owned tokens (FT/intents, where the API is primary and the tracker fills mint/burn). Only records inside a real gap are added → no double-counting; residual gas/reward/staking gaps are left as-is.

`FT_BACKFILL_VERSION` → 6.

## Validation (live prod data, petersalomonsen.near)

| | result |
|---|---|
| NEAR transfer records recovered | **+326** (incl. −200 & −1000 NEAR treasury moves) |
| NEAR (block,amount) duplicates | **0** |
| FT/intents block-level gaps | still 0 |
| NEAR continuity gaps | 193 → 128 (residual = gas/reward dust + staking liquid-side, not transactions) |

Tests: 122 unit + 4 integration.

> Note: this is the event-level NEAR fix (captures the missing *transactions*). The larger "API-first, RPC-authority, binary-search-only-for-gaps" discovery-core refactor remains a separate optimization — the shadow run de-risked it (RPC≈API), but it's a bigger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)