### PR TITLE
Preserve ftBackfillVersion across balance-tracker load/save

### DIFF
--- a/scripts/get-account-history.ts
+++ b/scripts/get-account-history.ts
@@ -128,6 +128,10 @@ interface AccountHistoryV2 {
         lastBlock: number | null;
         totalRecords: number;
         historyComplete?: boolean;
+        // Owned by the transfers-API sync (transfers-sync.ts). Must round-trip
+        // through load/save here, or it gets wiped each cycle and the account
+        // re-runs a full transfers backfill forever.
+        ftBackfillVersion?: number;
     };
 }
 
@@ -146,6 +150,7 @@ interface AccountHistory {
         totalTransactions: number;
         totalRecords?: number;
         historyComplete?: boolean;
+        ftBackfillVersion?: number;  // preserved for transfers-sync (see V2 type)
     };
 }
 
@@ -258,6 +263,7 @@ function loadExistingHistory(filePath: string): AccountHistory | null {
                     stakingPools: parsed.stakingPools,
                     discoveredFtContracts: parsed.discoveredFtContracts,
                     metadata: {
+                        ftBackfillVersion: parsed.metadata.ftBackfillVersion,
                         firstBlock: parsed.metadata.firstBlock,
                         lastBlock: parsed.metadata.lastBlock,
                         totalTransactions: 0,
@@ -317,7 +323,10 @@ function saveHistory(filePath: string, history: AccountHistory): void {
             firstBlock,
             lastBlock,
             totalRecords: allRecords.length,
-            historyComplete: history.metadata.historyComplete
+            historyComplete: history.metadata.historyComplete,
+            // Preserve the transfers-sync marker so the balance-tracker's saves
+            // don't wipe it (which would trigger a full re-backfill every cycle).
+            ftBackfillVersion: history.metadata.ftBackfillVersion
         }
     };
 


### PR DESCRIPTION
## Problem

The transfers-sync writes `metadata.ftBackfillVersion` to mark an account as backfilled. But the balance-tracker's `loadExistingHistory`/`saveHistory` rebuild `metadata` from scratch (firstBlock/lastBlock/totalRecords/historyComplete only), **dropping** `ftBackfillVersion`.

So for any account the tracker re-saves every cycle (history-incomplete or active accounts), the marker is wiped → `transfers-sync` sees `needsBackfill=true` → runs a **full transfers backfill every cycle**. That's the sustained external-API traffic observed after the spike settled.

petersalomonsen.near was unaffected only because it's history-complete and rarely re-saved (so its v6 marker stuck); `stianforland.near` / `arizportfolio.near` showed `Transfers sync: ... (backfill)` on every cycle.

## Fix

Round-trip `ftBackfillVersion` through both load and save (and add it to the metadata types). One account written by the tracker now keeps its marker, so the backfill runs once and then goes incremental.

Tests: 122 unit passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)