### PR TITLE
Include NEAR in the incremental transfers-fetch boundary

### DIFF
--- a/scripts/transfers-sync.ts
+++ b/scripts/transfers-sync.ts
@@ -284,11 +284,19 @@ export async function mergeFtTransferRecords(
     return { records, fetched: ownedFetched.length, gaps, filled };
 }
 
-/** Highest block among transfers-API-owned records (FT + intents); 0 if none. */
-export function latestOwnedBlock(records: BalanceChangeRecord[]): number {
+/**
+ * Highest block among records the transfers API supplies — FT + intents (owned)
+ * AND NEAR. Used as the incremental fetch boundary. Must include NEAR: otherwise
+ * NEAR-only accounts (no FT/intents) get a boundary of 0 and re-fetch their whole
+ * transfer history every cycle. Safe after a full backfill, since everything up
+ * to this block has already been fetched. 0 if none.
+ */
+export function latestSyncedBlock(records: BalanceChangeRecord[]): number {
     let max = 0;
     for (const r of records) {
-        if (isTransfersOwned(r.token_id) && r.block_height > max) max = r.block_height;
+        if ((isTransfersOwned(r.token_id) || r.token_id === 'near') && r.block_height > max) {
+            max = r.block_height;
+        }
     }
     return max;
 }
@@ -371,7 +379,7 @@ export async function syncFtTransfersForAccount(
     // NEAR and staking records are never touched.
     const needsBackfill = data.metadata.ftBackfillVersion !== FT_BACKFILL_VERSION;
     const backfill = needsBackfill || opts.backfill === true;
-    const afterBlock = backfill ? 0 : latestOwnedBlock(existing);
+    const afterBlock = backfill ? 0 : latestSyncedBlock(existing);
 
     const fetched = await fetchRecords(accountId, { afterBlock: afterBlock || undefined });
     const result = await mergeFtTransferRecords(existing, fetched, { ...opts, backfill });

--- a/test/unit/transfers-sync.test.ts
+++ b/test/unit/transfers-sync.test.ts
@@ -7,7 +7,7 @@ import {
     isFtToken,
     isIntentsToken,
     isTransfersOwned,
-    latestOwnedBlock,
+    latestSyncedBlock,
     mergeFtTransferRecords,
     syntheticGapSampler,
     syncFtTransfersForAccount,
@@ -57,16 +57,21 @@ describe('token classification', function () {
     });
 });
 
-describe('latestOwnedBlock', function () {
-    it('returns the max block among owned (FT + intents) records', () => {
+describe('latestSyncedBlock', function () {
+    it('returns the max block among FT + intents + NEAR (not staking)', () => {
         const records = [
-            rec({ token_id: 'npro.nearmobile.near', block_height: 100 }),
-            rec({ token_id: 'near', block_height: 999 }),               // ignored
-            rec({ token_id: 'npro.poolv1.near', block_height: 888 }),   // ignored (staking)
-            rec({ token_id: 'nep141:npro.nearmobile.near', block_height: 300 }), // intents counted
+            rec({ token_id: 'npro.nearmobile.near', block_height: 100 }),       // FT
+            rec({ token_id: 'nep141:npro.nearmobile.near', block_height: 300 }), // intents
+            rec({ token_id: 'near', block_height: 500 }),                       // NEAR counted now
+            rec({ token_id: 'npro.poolv1.near', block_height: 888 }),           // staking ignored
         ];
-        assert.equal(latestOwnedBlock(records), 300);
-        assert.equal(latestOwnedBlock([]), 0);
+        assert.equal(latestSyncedBlock(records), 500);
+        assert.equal(latestSyncedBlock([]), 0);
+    });
+
+    it('uses NEAR when there are no owned tokens (avoids full re-fetch each cycle)', () => {
+        const records = [rec({ token_id: 'near', block_height: 777 })];
+        assert.equal(latestSyncedBlock(records), 777);
     });
 });
 


### PR DESCRIPTION
The incremental `afterBlock` used `latestOwnedBlock` (FT + intents only). Accounts with **no FT/intents** (NEAR-only) got boundary 0 and **re-fetched their entire native:near transfer history every cycle**; accounts whose last FT move is old but still move NEAR re-fetched from that stale block. That's wasteful transfers-API traffic the NEAR-fill change added.

Fix: `latestSyncedBlock` now includes `native:near`. Safe post-backfill (everything up to this block is already fetched). No change to ledger output.

122 unit tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)