### PR TITLE
Add RPC gap-sampler (building block for API-first discovery)

### DIFF
--- a/scripts/rpc-gap-sampler.ts
+++ b/scripts/rpc-gap-sampler.ts
@@ -1,0 +1,89 @@
+// RPC gap-sampler — the "RPC only for gaps" fallback.
+//
+// The transfers API gives every TRANSFER (with block-level balances), so the
+// ledger is built from it with zero RPC. What the API can't see are NON-transfer
+// balance changes — wNEAR/bridge mint & burn, unwraps. Those show up as a
+// per-token block-level gap: the balance jumps between two API records with no
+// transfer in between.
+//
+// This sampler resolves such a gap with a BOUNDED binary search over RPC: the
+// balance is `expected_balance` at from_block and `actual_balance` at to_block,
+// so we bisect the (from_block, to_block] range to find the exact block where it
+// changed, then emit one real record there. Cost is ~log2(gap size) RPC calls,
+// and only for the rare genuine gaps — not for every block like the old path.
+
+import { getAllBalances } from './balance-tracker.js';
+import { getBlockTimestamp } from './rpc.js';
+import type { BalanceChangeRecord, TokenGap } from './balance-tracker.js';
+import type { GapSampler } from './fastnear-transfers-api.js';
+
+/** Reads the on-chain balance of one owned token (FT / intents / NEAR) at a block. */
+export type BalanceAt = (token: string, block: number) => Promise<string>;
+type BlockTime = (block: number) => Promise<number | null>;
+
+/** Default BalanceAt backed by getAllBalances (one RPC view per call). */
+export function rpcBalanceAt(accountId: string): BalanceAt {
+    return async (token, block) => {
+        if (token === 'near') {
+            return (await getAllBalances(accountId, block, null, null, true, null)).near;
+        }
+        if (token.startsWith('nep141:') || token.startsWith('nep245:')) {
+            const snap = await getAllBalances(accountId, block, null, [token], false, null);
+            return snap.intentsTokens[token] ?? '0';
+        }
+        // bare FT contract
+        const snap = await getAllBalances(accountId, block, [token], null, false, null);
+        return snap.fungibleTokens[token] ?? '0';
+    };
+}
+
+export interface RpcGapSamplerOptions {
+    balanceAt?: BalanceAt;       // injectable for tests
+    blockTimestamp?: BlockTime;  // injectable for tests
+    maxBisectSteps?: number;     // safety cap on RPC per gap
+}
+
+/**
+ * Build a GapSampler that resolves a non-transfer balance gap to a real record
+ * via bounded binary search. Returns [] if it can't pin the change down (the gap
+ * is then left rather than guessed).
+ */
+export function makeRpcGapSampler(accountId: string, opts: RpcGapSamplerOptions = {}): GapSampler {
+    const balanceAt = opts.balanceAt ?? rpcBalanceAt(accountId);
+    const blockTime = opts.blockTimestamp ?? getBlockTimestamp;
+    const maxSteps = opts.maxBisectSteps ?? 32;
+
+    return async (gap: TokenGap): Promise<BalanceChangeRecord[]> => {
+        const expected = gap.expected_balance; // balance at/after from_block
+        const actual = gap.actual_balance;     // balance at/before to_block
+        let lo = gap.from_block;                // balance(lo) === expected
+        let hi = gap.to_block;                  // balance(hi) === actual
+
+        // Bisect to the first block whose balance is no longer `expected`.
+        let steps = 0;
+        while (hi - lo > 1 && steps < maxSteps) {
+            steps++;
+            const mid = Math.floor((lo + hi) / 2);
+            const bal = await balanceAt(gap.token_id, mid);
+            if (bal === expected) lo = mid; else hi = mid;
+        }
+        if (hi - lo !== 1) return []; // couldn't isolate a single change block
+
+        const ts = await blockTime(hi);
+        return [{
+            block_height: hi,
+            block_timestamp: ts != null ? new Date(Math.floor(ts / 1_000_000)).toISOString() : null,
+            tx_hash: null,
+            tx_block: null,
+            signer_id: null,
+            receiver_id: null,
+            predecessor_id: null,
+            token_id: gap.token_id,
+            receipt_id: null,
+            counterparty: null,
+            amount: (BigInt(actual) - BigInt(expected)).toString(),
+            balance_before: expected,
+            balance_after: actual,
+        }];
+    };
+}

--- a/test/unit/rpc-gap-sampler.test.ts
+++ b/test/unit/rpc-gap-sampler.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from 'mocha';
+import assert from 'assert';
+import { makeRpcGapSampler } from '../../scripts/rpc-gap-sampler.js';
+import type { TokenGap } from '../../scripts/balance-tracker.js';
+
+// A gap: wrap.near balance is 10 up to (and incl.) block 149, then 50 from 150 on
+// — a non-transfer mint of 40 at block 150 inside the (100, 200] gap.
+function balanceAtFor(changeBlock: number, before: string, after: string) {
+    let calls = 0;
+    const fn = async (_token: string, block: number) => {
+        calls++;
+        return block < changeBlock ? before : after;
+    };
+    return { fn, calls: () => calls };
+}
+
+const gap: TokenGap = {
+    token_id: 'wrap.near',
+    from_block: 100,
+    to_block: 200,
+    expected_balance: '10',
+    actual_balance: '50',
+    diff: '40',
+};
+
+describe('makeRpcGapSampler', function () {
+    it('bisects to the exact mint block and emits one real record', async () => {
+        const b = balanceAtFor(150, '10', '50');
+        const sampler = makeRpcGapSampler('acct.near', {
+            balanceAt: b.fn,
+            blockTimestamp: async () => 1_700_000_000_000_000_000, // ns
+        });
+        const out = await sampler(gap);
+        assert.equal(out.length, 1);
+        assert.equal(out[0]!.block_height, 150, 'found the change block');
+        assert.equal(out[0]!.amount, '40');
+        assert.equal(out[0]!.balance_before, '10');
+        assert.equal(out[0]!.balance_after, '50');
+        assert.equal(out[0]!.token_id, 'wrap.near');
+        assert.ok(out[0]!.block_timestamp, 'has a real timestamp (not null)');
+        // ~log2(100) calls, not 100
+        assert.ok(b.calls() <= 8, `bounded RPC: ${b.calls()} calls`);
+    });
+
+    it('respects the bisect step cap (returns [] rather than spinning)', async () => {
+        const b = balanceAtFor(150, '10', '50');
+        const sampler = makeRpcGapSampler('acct.near', {
+            balanceAt: b.fn,
+            blockTimestamp: async () => 1_700_000_000_000_000_000,
+            maxBisectSteps: 2,
+        });
+        // huge range, only 2 steps -> can't isolate -> []
+        const out = await sampler({ ...gap, from_block: 0, to_block: 1_000_000 });
+        assert.deepEqual(out, []);
+    });
+});


### PR DESCRIPTION
Lands the **gap-sampler** as a tested, standalone building block for the upcoming API-first discovery refactor. **Not wired into the worker** — zero behavior change.

It's the "RPC only for gaps" fallback: given a per-token block-level gap (a non-transfer balance change the transfers API can't represent — wNEAR/bridge mint & burn), it bounded-binary-searches to the exact change block (~log2(gap) RPC calls) and emits one real record. That's what makes it safe to later turn off the balance-tracker's redundant *per-block* FT/intents RPC sampling — the core of the recent FastNear traffic increase.

On-chain validation (petersalomonsen.near USDC.e bridge burn): correct amount/balances, and it pinned the change to the RPC-authoritative block, revealing the legacy tracker had mis-attributed it.

Unit-tested (bisect + step-cap). Full suite 125 passing. No gateway bump / deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)