### PR TITLE
Add per-cycle outbound-request metrics by host (diagnostic)

### DIFF
--- a/scripts/api-server.ts
+++ b/scripts/api-server.ts
@@ -17,6 +17,7 @@ import { detectGapsV2 } from './gap-detection.js';
 import { migrateToV2 } from './migrate-to-flat-format.js';
 import { isStakingPool } from './balance-tracker.js';
 import { syncFtTransfersForAccount } from './transfers-sync.js';
+import { instrumentFetch, snapshotAndReset, formatCounts } from './request-metrics.js';
 import type { GapAnalysisV2 } from './gap-detection.js';
 import type { BalanceChangeRecord } from './balance-tracker.js';
 
@@ -624,6 +625,7 @@ export function createRouter(config: RouterConfig): Router {
  * await worker.stop();
  */
 export async function startWorker(config: WorkerConfig = {}): Promise<WorkerHandle> {
+    instrumentFetch(); // count outbound requests by host (per-cycle diagnostic)
     const dataDir = config.dataDir || process.env.DATA_DIR || path.join(process.cwd(), 'data');
     const storage = createStorage(dataDir);
 
@@ -820,7 +822,7 @@ export async function startWorker(config: WorkerConfig = {}): Promise<WorkerHand
                 }
 
                 if (processedCount > 0 || skippedCount > 0) {
-                    console.log(`=== Sync cycle: ${processedCount} processed, ${skippedCount} skipped, ${deferredCount} deferred (not due yet) ===\n`);
+                    console.log(`=== Sync cycle: ${processedCount} processed, ${skippedCount} skipped, ${deferredCount} deferred (not due yet) === ${formatCounts(snapshotAndReset())}\n`);
                 }
 
                 // Wait before next cycle (unless shutting down)

--- a/scripts/request-metrics.ts
+++ b/scripts/request-metrics.ts
@@ -1,0 +1,38 @@
+// Lightweight outbound-request metrics. Wraps global fetch to count requests by
+// host so we can see, per sync cycle, where the worker's external traffic goes
+// (FastNear RPC vs tx API vs transfers API, neardata, indexers). Diagnostic only.
+
+const counts = new Map<string, number>();
+let patched = false;
+
+/** Monkey-patch global fetch once to count requests by host. Idempotent. */
+export function instrumentFetch(): void {
+    if (patched) return;
+    patched = true;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async (input: any, init?: any) => {
+        try {
+            const url = typeof input === 'string' ? input : (input?.url ?? String(input));
+            const host = new URL(url).host;
+            counts.set(host, (counts.get(host) || 0) + 1);
+        } catch {
+            // ignore unparseable inputs
+        }
+        return orig(input, init);
+    }) as typeof fetch;
+}
+
+/** Return the per-host counts since the last reset and clear them. */
+export function snapshotAndReset(): Record<string, number> {
+    const out = Object.fromEntries(counts);
+    counts.clear();
+    return out;
+}
+
+/** Compact one-line summary, largest hosts first. */
+export function formatCounts(c: Record<string, number>): string {
+    const entries = Object.entries(c).sort((a, b) => b[1] - a[1]);
+    const total = entries.reduce((s, [, n]) => s + n, 0);
+    if (total === 0) return 'requests: 0';
+    return `requests: ${total} | ` + entries.map(([h, n]) => `${h}=${n}`).join(' ');
+}


### PR DESCRIPTION
Wraps global fetch to count requests by host, logged per sync cycle. Gives worker-only traffic breakdown (FastNear RPC vs tx API vs transfers API vs neardata/indexers) so we can pinpoint the FastNear usage increase — the dashboard can't separate it (single key, shared with local testing). Counting only, no behavior change. 125 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)