### PR TITLE
Complete incomplete accounts via NEAR tx-index builder (stops backward search)

### DIFF
--- a/scripts/api-server.ts
+++ b/scripts/api-server.ts
@@ -17,6 +17,7 @@ import { detectGapsV2 } from './gap-detection.js';
 import { migrateToV2 } from './migrate-to-flat-format.js';
 import { isStakingPool } from './balance-tracker.js';
 import { syncFtTransfersForAccount } from './transfers-sync.js';
+import { syncNearLedgerForAccount } from './near-tx-ledger.js';
 import { instrumentFetch, snapshotAndReset, formatCounts } from './request-metrics.js';
 import type { GapAnalysisV2 } from './gap-detection.js';
 import type { BalanceChangeRecord } from './balance-tracker.js';
@@ -701,8 +702,25 @@ export async function startWorker(config: WorkerConfig = {}): Promise<WorkerHand
                     return;
                 }
 
-                // Then do incremental backward search if history is not complete
+                // For incomplete accounts, rebuild the NEAR ledger from the tx index
+                // (one bounded, on-chain-accurate pass) and mark complete. This both
+                // recovers missing history and STOPS the recurring backward binary
+                // search — the steady-state RPC hotspot.
+                let nowComplete = historyComplete;
                 if (!historyComplete) {
+                    try {
+                        const nearSync = await syncNearLedgerForAccount(accountId, outputFile);
+                        if (nearSync.changed) {
+                            nowComplete = true;
+                            console.log(`[${accountId}] NEAR ledger rebuilt from tx index: ${nearSync.nearRecords} records, ${nearSync.rpcReads} reads — marked complete`);
+                        }
+                    } catch (error) {
+                        console.error(`[${accountId}] NEAR ledger sync failed:`, error);
+                    }
+                }
+
+                // Then do incremental backward search if history is still not complete
+                if (!nowComplete) {
                     console.log(`[${accountId}] Searching backward (incremental - history incomplete)`);
                     result.backward = true;
 

--- a/scripts/near-tx-ledger.ts
+++ b/scripts/near-tx-ledger.ts
@@ -16,9 +16,10 @@
 //     samples give before→after per group. ~1 archival read per transaction group,
 //     vs the old binary-search + per-change-block sampling.
 
+import fs from 'fs';
 import { getAllFastNearTxTransactionBlocks } from './fastnear-tx-api.js';
 import { getAllBalances } from './balance-tracker.js';
-import { getBlockTimestamp } from './rpc.js';
+import { getBlockTimestamp, getCurrentBlockHeight } from './rpc.js';
 import type { BalanceChangeRecord } from './balance-tracker.js';
 
 // Receipts (incl. the gas refund) settle within a few blocks of the tx block.
@@ -119,4 +120,60 @@ export async function buildNearLedger(
 
     records.sort((a, b) => b.block_height - a.block_height);
     return { records, rpcReads };
+}
+
+export interface SyncNearResult {
+    changed: boolean;
+    nearRecords?: number;
+    rpcReads?: number;
+    reason?: string;
+}
+
+/**
+ * Rebuild an account's NEAR ledger from the tx index and mark it historyComplete.
+ *
+ * Targets the perpetually-"incomplete" accounts whose backward binary search runs
+ * every cycle and never finishes — the steady-state RPC hotspot. The tx index
+ * gives the complete transaction list back to creation, so one bounded pass
+ * produces an authoritative, on-chain-accurate NEAR ledger AND lets us mark the
+ * account complete (the worker then skips the backward search entirely).
+ *
+ * Already-complete accounts are skipped (no backward-search problem) unless
+ * opts.force. NEAR records are replaced; all other tokens are untouched.
+ */
+export async function syncNearLedgerForAccount(
+    accountId: string,
+    outputFile: string,
+    opts: { force?: boolean; currentBlock?: number } & Pick<NearLedgerOptions, 'fetchTxBlocks' | 'nearBalanceAt' | 'blockTimestamp'> = {}
+): Promise<SyncNearResult> {
+    if (!fs.existsSync(outputFile)) return { changed: false, reason: 'no-file' };
+    const data = JSON.parse(fs.readFileSync(outputFile, 'utf-8'));
+    if (data.version !== 2 || !Array.isArray(data.records)) return { changed: false, reason: 'not-v2' };
+
+    data.metadata = data.metadata || {};
+    if (data.metadata.historyComplete === true && !opts.force) {
+        return { changed: false, reason: 'already-complete' };
+    }
+
+    const currentBlock = opts.currentBlock ?? await getCurrentBlockHeight();
+    const { records: nearRecords, rpcReads } = await buildNearLedger(accountId, {
+        currentBlock,
+        fetchTxBlocks: opts.fetchTxBlocks,
+        nearBalanceAt: opts.nearBalanceAt,
+        blockTimestamp: opts.blockTimestamp,
+    });
+
+    const nonNear = data.records.filter((r: BalanceChangeRecord) => r.token_id !== 'near');
+    const merged = [...nonNear, ...nearRecords].sort((a, b) => b.block_height - a.block_height);
+    data.records = merged;
+    if (merged.length > 0) {
+        const blocks = merged.map((r: BalanceChangeRecord) => r.block_height);
+        data.metadata.firstBlock = Math.min(...blocks);
+        data.metadata.lastBlock = Math.max(...blocks);
+    }
+    data.metadata.totalRecords = merged.length;
+    data.metadata.historyComplete = true; // tx index covers all history -> stop the backward search
+    data.updatedAt = new Date().toISOString();
+    fs.writeFileSync(outputFile, JSON.stringify(data, null, 2));
+    return { changed: true, nearRecords: nearRecords.length, rpcReads };
 }

--- a/test/unit/near-tx-ledger.test.ts
+++ b/test/unit/near-tx-ledger.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from 'mocha';
 import assert from 'assert';
-import { groupTxBlocks, buildNearLedger, SETTLE_BUFFER } from '../../scripts/near-tx-ledger.js';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { groupTxBlocks, buildNearLedger, syncNearLedgerForAccount, SETTLE_BUFFER } from '../../scripts/near-tx-ledger.js';
 
 describe('groupTxBlocks', function () {
     it('merges tx blocks that settle within SETTLE_BUFFER, splits the rest', () => {
@@ -70,5 +73,55 @@ describe('buildNearLedger', function () {
             blockTimestamp: async () => 1_700_000_000_000_000_000,
         });
         assert.deepEqual(records, []);
+    });
+});
+
+describe('syncNearLedgerForAccount', function () {
+    const writeFile = (meta: any, records: any[]) => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'near-'));
+        const file = path.join(dir, 'a.json');
+        fs.writeFileSync(file, JSON.stringify({ version: 2, accountId: 'a.near', records, metadata: meta }));
+        return { dir, file };
+    };
+
+    it('rebuilds NEAR, preserves other tokens, and marks complete (incomplete account)', async () => {
+        const { dir, file } = writeFile(
+            { historyComplete: false, firstBlock: 100, lastBlock: 100, totalRecords: 2 },
+            [
+                { token_id: 'near', block_height: 100, balance_before: '0', balance_after: '5', amount: '5' },
+                { token_id: 'npro.nearmobile.near', block_height: 100, balance_before: '0', balance_after: '9', amount: '9' },
+            ]
+        );
+        const res = await syncNearLedgerForAccount('a.near', file, {
+            currentBlock: 1000,
+            fetchTxBlocks: async () => [300],
+            nearBalanceAt: async (b) => (b < 300 ? '5' : '7'),
+            blockTimestamp: async () => 1_700_000_000_000_000_000,
+        });
+        assert.equal(res.changed, true);
+        const d = JSON.parse(fs.readFileSync(file, 'utf-8'));
+        assert.equal(d.metadata.historyComplete, true, 'marked complete -> backward search will be skipped');
+        const near = d.records.filter((r: any) => r.token_id === 'near');
+        assert.equal(near.length, 1, 'NEAR rebuilt from tx index');
+        assert.equal(near[0].block_height, 300);
+        assert.ok(d.records.some((r: any) => r.token_id === 'npro.nearmobile.near'), 'other tokens preserved');
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('skips already-complete accounts (no rebuild, no RPC)', async () => {
+        const { dir, file } = writeFile(
+            { historyComplete: true, firstBlock: 1, lastBlock: 1, totalRecords: 1 },
+            [{ token_id: 'near', block_height: 1, balance_before: '0', balance_after: '1', amount: '1' }]
+        );
+        let fetched = false;
+        const res = await syncNearLedgerForAccount('a.near', file, {
+            currentBlock: 1000,
+            fetchTxBlocks: async () => { fetched = true; return [5]; },
+            nearBalanceAt: async () => '1',
+        });
+        assert.equal(res.changed, false);
+        assert.equal(res.reason, 'already-complete');
+        assert.equal(fetched, false, 'no tx-index fetch for complete accounts');
+        fs.rmSync(dir, { recursive: true, force: true });
     });
 });


### PR DESCRIPTION
## The fix

The instrumentation showed **~94% of traffic is archival RPC**, and the steady-state hotspot is the **4 perpetually-incomplete accounts** running a backward binary search every 5 min that never finishes.

This wires `syncNearLedgerForAccount` (built on the merged `buildNearLedger`) into the worker: for an incomplete account, rebuild the NEAR ledger from the **tx index** (one bounded, on-chain-accurate pass — no binary search) and mark it `historyComplete`, so the worker **skips the backward search**. The account then moves to the 8h interval instead of every 5 min.

Both **recovers missing history** (arizportfolio 95→440 records — the backward search never captured it) and **removes the recurring archival traffic**.

## Validated on-chain (all 4 incomplete accounts)

| account | records | RPC (1-time) | gaps | final == on-chain |
|---|---|---|---|---|
| arizportfolio | 440 | 473 | 0 | ✅ |
| stianforland | 100 | 114 | 0 | ✅ |
| ariz_market | 202 | 211 | 0 | ✅ |
| arizcredits | 112 | 127 | 0 | ✅ |

Already-complete accounts are skipped (no rebuild, no RPC); non-NEAR tokens untouched. 132 unit tests pass. The per-cycle metrics will show the archival count fall after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)