### PR TITLE
Self-heal dropped FT claims via transfers API; gate historyComplete on token gaps

### DIFF
--- a/scripts/transfers-sync.ts
+++ b/scripts/transfers-sync.ts
@@ -58,6 +58,24 @@ export function isTransfersOwned(tokenId: string): boolean {
     return isFtToken(tokenId) || isIntentsToken(tokenId);
 }
 
+/**
+ * Inverse of assetIdToTokenId: map a V2 token_id back to the transfers-API
+ * asset_id, so we can re-query the API for a single token (server-side filter).
+ *   - bare FT contract "X"        -> "nep141:X"
+ *   - intents balance "nep141:X"  -> "nep245:intents.near:nep141:X"
+ * Returns null for tokens the transfers API doesn't own (NEAR, staking).
+ */
+export function tokenIdToAssetId(tokenId: string): string | null {
+    if (!isTransfersOwned(tokenId)) return null;
+    if (isIntentsToken(tokenId)) {
+        const inner = tokenId.startsWith('nep245:intents.near:')
+            ? tokenId.slice('nep245:intents.near:'.length)
+            : tokenId;
+        return `nep245:intents.near:${inner}`;
+    }
+    return `nep141:${tokenId}`;
+}
+
 /** Stable identity for an FT record so the authoritative version replaces a stale one. */
 function ftKey(r: BalanceChangeRecord): string {
     return `${r.token_id}|${r.receipt_id ?? r.block_height}|${r.amount}`;
@@ -284,6 +302,76 @@ export async function mergeFtTransferRecords(
     return { records, fetched: ownedFetched.length, gaps, filled };
 }
 
+export interface FillGapsResult {
+    /** Full record set with gapped owned tokens repaired from the API ledger. */
+    records: BalanceChangeRecord[];
+    /** Owned-token discontinuities remaining after the repair. */
+    gaps: TokenGap[];
+    /** Net owned records added while repairing. */
+    filled: number;
+}
+
+/**
+ * Repair per-token balance discontinuities using the transfers API itself.
+ *
+ * The incremental fetch boundary (latestSyncedBlock) is a single watermark across
+ * ALL tokens incl. NEAR. The NEAR balance-tracker advances it every cycle, so an
+ * FT claim / intents deposit that settles a couple blocks below the watermark is
+ * never fetched — it surfaces only later as a discontinuity (the next transfer of
+ * that token starts from a balance that "appears from nowhere"). detectTokenGaps
+ * catches that; this closes it.
+ *
+ * For each owned token that has a gap, re-fetch its FULL authoritative ledger
+ * (server-side asset_id filter — cheap, one token) and adopt it, bridging any
+ * non-transfer balance moves (mint/burn) with the existing records. The transfers
+ * API reports every transfer with start/end-of-block balances, so the recovered
+ * records carry the real amount, balances and tx hash — i.e. the missing credit
+ * lands on the same transaction that previously showed only its NEAR gas cost.
+ *
+ * Remaining gaps after a full re-fetch are irreducible from the transfers API
+ * (e.g. swap-heavy intents tokens that settle several transfers per block, so the
+ * per-transfer block snapshots don't chain) and are returned for the caller to
+ * report — they do not indicate genuinely-missing data.
+ */
+export async function fillOwnedGapsFromApi(
+    accountId: string,
+    records: BalanceChangeRecord[],
+    fetchRecords: (
+        accountId: string,
+        options: GetAllTransfersOptions
+    ) => Promise<BalanceChangeRecord[]>
+): Promise<FillGapsResult> {
+    const gaps = detectTokenGaps(records.filter(r => isTransfersOwned(r.token_id)));
+    if (gaps.length === 0) return { records, gaps, filled: 0 };
+
+    const gappedTokens = [...new Set(gaps.map(g => g.token_id))].filter(isTransfersOwned);
+    const byToken = groupByToken(records);
+    let filled = 0;
+
+    for (const token of gappedTokens) {
+        const assetId = tokenIdToAssetId(token);
+        if (!assetId) continue;
+        let ledger: BalanceChangeRecord[];
+        try {
+            ledger = (await fetchRecords(accountId, { assetId })).filter(r => r.token_id === token);
+        } catch {
+            // Transient API error: leave this token's gap for a later cycle.
+            continue;
+        }
+        if (ledger.length === 0) continue;
+        const existingForToken = byToken.get(token) ?? [];
+        // Adopt the authoritative ledger, then bridge non-transfer moves the API
+        // can't represent with the existing balance-tracker records.
+        const adopted = [...ledger, ...fillBlockGapsFromExisting(ledger, existingForToken)];
+        filled += Math.max(0, adopted.length - existingForToken.length);
+        byToken.set(token, adopted);
+    }
+
+    const merged = [...byToken.values()].flat().sort((a, b) => b.block_height - a.block_height);
+    const remaining = detectTokenGaps(merged.filter(r => isTransfersOwned(r.token_id)));
+    return { records: merged, gaps: remaining, filled };
+}
+
 /**
  * Highest block among records the transfers API supplies — FT + intents (owned)
  * AND NEAR. Used as the incremental fetch boundary. Must include NEAR: otherwise
@@ -382,13 +470,34 @@ export async function syncFtTransfersForAccount(
     const afterBlock = backfill ? 0 : latestSyncedBlock(existing);
 
     const fetched = await fetchRecords(accountId, { afterBlock: afterBlock || undefined });
-    const result = await mergeFtTransferRecords(existing, fetched, { ...opts, backfill });
+    let result = await mergeFtTransferRecords(existing, fetched, { ...opts, backfill });
+
+    // Safety net: if any owned token has a balance discontinuity (the incremental
+    // watermark skipped an FT claim / intents deposit), repair it directly from
+    // the transfers API — re-fetch the gapped token's full ledger and adopt it.
+    if (result.gaps.length > 0) {
+        const repaired = await fillOwnedGapsFromApi(accountId, result.records, fetchRecords);
+        result = {
+            records: repaired.records,
+            fetched: result.fetched,
+            gaps: repaired.gaps,
+            filled: result.filled + repaired.filled,
+        };
+    }
+
+    // Genuinely-missing FT data keeps the account "incomplete" so the sync loop
+    // re-visits it frequently until the transfers API has indexed the credit.
+    // (Intents block-level gaps are expected — several settlements per block — and
+    // don't flip the flag, otherwise swap-heavy accounts would never be complete.)
+    const unfilledFtGaps = result.gaps.filter(g => isFtToken(g.token_id));
+    const flipIncomplete = unfilledFtGaps.length > 0 && data.metadata.historyComplete === true;
 
     const changed =
         result.records.length !== existing.length ||
         result.fetched > 0 ||
         result.filled > 0 ||
-        needsBackfill;
+        needsBackfill ||
+        flipIncomplete;
 
     if (changed) {
         const blocks = result.records.map(r => r.block_height);
@@ -400,6 +509,9 @@ export async function syncFtTransfersForAccount(
         data.metadata.totalRecords = result.records.length;
         // Only mark backfilled once the full re-fetch actually succeeded.
         data.metadata.ftBackfillVersion = FT_BACKFILL_VERSION;
+        if (flipIncomplete) {
+            data.metadata.historyComplete = false;
+        }
         data.updatedAt = opts.now ?? new Date().toISOString();
         fs.writeFileSync(outputFile, JSON.stringify(data, null, 2));
     }

--- a/test/unit/transfers-sync.test.ts
+++ b/test/unit/transfers-sync.test.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import {
+    fillOwnedGapsFromApi,
     isFtToken,
     isIntentsToken,
     isTransfersOwned,
@@ -11,6 +12,7 @@ import {
     mergeFtTransferRecords,
     syntheticGapSampler,
     syncFtTransfersForAccount,
+    tokenIdToAssetId,
 } from '../../scripts/transfers-sync.js';
 import type { BalanceChangeRecord } from '../../scripts/balance-tracker.js';
 
@@ -341,6 +343,120 @@ describe('syncFtTransfersForAccount', function () {
         fs.writeFileSync(file, JSON.stringify({ accountId: 'a', transactions: [] }));
         const result = await syncFtTransfersForAccount('a', file, { fetchRecords: async () => { throw new Error('should not fetch'); } });
         assert.equal(result.changed, false);
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+});
+
+describe('tokenIdToAssetId', function () {
+    it('inverts assetIdToTokenId for FT, intents, and rejects non-owned', () => {
+        assert.equal(tokenIdToAssetId('npro.nearmobile.near'), 'nep141:npro.nearmobile.near');
+        assert.equal(tokenIdToAssetId('nep141:npro.nearmobile.near'), 'nep245:intents.near:nep141:npro.nearmobile.near');
+        assert.equal(tokenIdToAssetId('near'), null);
+        assert.equal(tokenIdToAssetId('binancenode1.poolv1.near'), null);
+    });
+});
+
+describe('fillOwnedGapsFromApi', function () {
+    it('repairs a dropped FT claim by re-adopting the token ledger from the API', async () => {
+        // A claim credit (block 200, +20) was skipped by the incremental watermark;
+        // only the later withdrawal (block 250) was recorded, so its balance "20"
+        // appears from nowhere -> a gap between block 150 and 250.
+        const gapped = [
+            rec({ token_id: 'near', block_height: 300, amount: '-1' }),
+            rec({ token_id: 'npro.nearmobile.near', block_height: 100, receipt_id: 'c1', amount: '10', balance_before: '0', balance_after: '10' }),
+            rec({ token_id: 'npro.nearmobile.near', block_height: 150, receipt_id: 'w1', amount: '-10', balance_before: '10', balance_after: '0' }),
+            rec({ token_id: 'npro.nearmobile.near', block_height: 250, receipt_id: 'w2', amount: '-20', balance_before: '20', balance_after: '0' }),
+        ];
+
+        let askedAsset: string | undefined;
+        const result = await fillOwnedGapsFromApi('acct.near', gapped, async (_acct, options) => {
+            askedAsset = options.assetId;
+            // Authoritative ledger from the transfers API: includes the missing claim.
+            return [
+                rec({ token_id: 'npro.nearmobile.near', block_height: 100, receipt_id: 'c1', amount: '10', balance_before: '0', balance_after: '10' }),
+                rec({ token_id: 'npro.nearmobile.near', block_height: 150, receipt_id: 'w1', amount: '-10', balance_before: '10', balance_after: '0' }),
+                rec({ token_id: 'npro.nearmobile.near', block_height: 200, receipt_id: 'CLAIM', amount: '20', balance_before: '0', balance_after: '20', tx_hash: 'claimtx' }),
+                rec({ token_id: 'npro.nearmobile.near', block_height: 250, receipt_id: 'w2', amount: '-20', balance_before: '20', balance_after: '0' }),
+            ];
+        });
+
+        assert.equal(askedAsset, 'nep141:npro.nearmobile.near', 'should re-query the gapped token by asset_id');
+        assert.equal(result.gaps.length, 0, 'gap closed after adopting the ledger');
+        assert.ok(result.records.some(r => r.receipt_id === 'CLAIM' && r.amount === '20'), 'missing claim credit recovered');
+        assert.ok(result.records.some(r => r.token_id === 'near'), 'NEAR records untouched');
+        assert.ok(result.filled >= 1);
+    });
+
+    it('is a no-op when there are no gaps', async () => {
+        const clean = [
+            rec({ token_id: 'npro.nearmobile.near', block_height: 100, amount: '10', balance_before: '0', balance_after: '10' }),
+        ];
+        const result = await fillOwnedGapsFromApi('a', clean, async () => { throw new Error('should not fetch'); });
+        assert.equal(result.gaps.length, 0);
+        assert.equal(result.filled, 0);
+    });
+});
+
+describe('syncFtTransfersForAccount — gap repair + historyComplete', function () {
+    const gappedFile = (extraMeta: Record<string, unknown> = {}) => ({
+        version: 2,
+        accountId: 'acct.near',
+        records: [
+            rec({ token_id: 'near', block_height: 300, amount: '-1' }),
+            rec({ token_id: 'npro.nearmobile.near', block_height: 100, receipt_id: 'c1', amount: '10', balance_before: '0', balance_after: '10' }),
+            rec({ token_id: 'npro.nearmobile.near', block_height: 150, receipt_id: 'w1', amount: '-10', balance_before: '10', balance_after: '0' }),
+            rec({ token_id: 'npro.nearmobile.near', block_height: 250, receipt_id: 'w2', amount: '-20', balance_before: '20', balance_after: '0' }),
+        ],
+        metadata: { firstBlock: 100, lastBlock: 300, totalRecords: 4, ftBackfillVersion: 6, historyComplete: true, ...extraMeta },
+    });
+
+    const fullLedger = () => [
+        rec({ token_id: 'npro.nearmobile.near', block_height: 100, receipt_id: 'c1', amount: '10', balance_before: '0', balance_after: '10' }),
+        rec({ token_id: 'npro.nearmobile.near', block_height: 150, receipt_id: 'w1', amount: '-10', balance_before: '10', balance_after: '0' }),
+        rec({ token_id: 'npro.nearmobile.near', block_height: 200, receipt_id: 'CLAIM', amount: '20', balance_before: '0', balance_after: '20', tx_hash: 'claimtx' }),
+        rec({ token_id: 'npro.nearmobile.near', block_height: 250, receipt_id: 'w2', amount: '-20', balance_before: '20', balance_after: '0' }),
+    ];
+
+    it('fills the gap from the API and keeps historyComplete true', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ftsync-gap-'));
+        const file = path.join(dir, 'acct.json');
+        fs.writeFileSync(file, JSON.stringify(gappedFile(), null, 2));
+
+        const result = await syncFtTransfersForAccount('acct.near', file, {
+            now: '2026-06-20T00:00:00.000Z',
+            fetchRecords: async (_acct, options) => {
+                if (options.assetId === 'nep141:npro.nearmobile.near') return fullLedger();
+                return []; // incremental fetch finds nothing new
+            },
+        });
+
+        assert.ok(result.filled >= 1);
+        assert.equal(result.gaps.length, 0);
+        const written = JSON.parse(fs.readFileSync(file, 'utf-8'));
+        assert.ok(written.records.some((r: any) => r.receipt_id === 'CLAIM'), 'claim credit written');
+        assert.equal(written.metadata.historyComplete, true, 'stays complete once the gap is filled');
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('flips historyComplete to false when the API still lacks the credit', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ftsync-gap2-'));
+        const file = path.join(dir, 'acct.json');
+        fs.writeFileSync(file, JSON.stringify(gappedFile(), null, 2));
+
+        const result = await syncFtTransfersForAccount('acct.near', file, {
+            now: '2026-06-20T00:00:00.000Z',
+            // API hasn't indexed the claim yet: returns the same gapped ledger.
+            fetchRecords: async (_acct, options) => {
+                if (options.assetId === 'nep141:npro.nearmobile.near') {
+                    return fullLedger().filter(r => r.receipt_id !== 'CLAIM');
+                }
+                return [];
+            },
+        });
+
+        assert.ok(result.gaps.some(g => g.token_id === 'npro.nearmobile.near'), 'gap still open');
+        const written = JSON.parse(fs.readFileSync(file, 'utf-8'));
+        assert.equal(written.metadata.historyComplete, false, 'genuinely-missing FT data marks the account incomplete');
         fs.rmSync(dir, { recursive: true, force: true });
     });
 });


### PR DESCRIPTION
## Problem

For some FT claims (e.g. daily NEAR Mobile NPRO claims from `distribution.nearmobile.near`), the transaction appears in history with **only its NEAR gas cost** — the positive token credit is missing, so the balance increase is invisible.

Root cause: the incremental transfers fetch uses a single watermark (`latestSyncedBlock`) across **all** tokens including NEAR. The NEAR balance-tracker advances that watermark every cycle, so an FT credit that settles a couple blocks below it is never fetched. It later surfaces as a per-token discontinuity (`balance_after ≠ next balance_before`). `detectTokenGaps` flagged these, but `mergeFtTransferRecords` only filled them when an opt-in `sampler` was supplied (production passed none), and `historyComplete` was NEAR-only so token gaps never marked an account incomplete.

Confirmed against real data: `petersalomonsen.near` had **9 NPRO gaps (~237 NPRO)**, all daily distribution claims from the last ~10 days — and the FastNear transfers API has every one (with correct start/end balances), so this is purely an ingest gap.

## Fix

- **`fillOwnedGapsFromApi`** — for each owned token with a gap, re-fetch its full authoritative ledger from the transfers API (`asset_id` server-side filter) and adopt it, bridging non-transfer moves (mint/burn) with existing records. Recovered records carry the real amount, balances and **tx hash**, so the credit lands on the same transaction that previously showed only NEAR gas.
- **`syncFtTransfersForAccount`** runs the repair whenever a gap is detected, and flips `metadata.historyComplete = false` when genuinely-missing **FT** data remains (so the sync loop re-visits the account frequently until the API indexes the credit). Intents block-level gaps (several settlements per block) are expected and don't flip the flag, avoiding perpetual-incomplete on swap-heavy accounts.
- **`tokenIdToAssetId`** — inverse of `assetIdToTokenId`, for the per-token re-query.

Self-healing: existing accounts repair on their next sync cycle (the withdrawal that follows a claim creates the detectable gap), no forced backfill-version bump.

## Tests
+5 unit tests (claim-recovery, no-op, historyComplete stays-true-when-filled / flips-false-when-API-lags, `tokenIdToAssetId`). Full unit suite: **140 passing**, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)