### PR TITLE
Add MIT LICENSE file (align package.json, was ISC)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Peter Salomonsen (petersalomonsen.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "balance-tracker"
   ],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@near-js/jsonrpc-client": "^1.5.0",
     "@near-js/jsonrpc-types": "^1.5.0",


### PR DESCRIPTION
The repo was public with **no LICENSE file** (all-rights-reserved by default — nobody but the author could legally use it, despite ariz-gateway consuming it as a dependency) and an `ISC` placeholder in `package.json`. This adds the standard MIT text — copyright **Peter Salomonsen (petersalomonsen.com)**, 2025–2026 (first commit to now) — and aligns `package.json` to `MIT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)