### PR TITLE
Tail-balance reconciliation: catch non-transfer FT disposals (burns/redemptions)

### DIFF
--- a/scripts/api-server.ts
+++ b/scripts/api-server.ts
@@ -12,7 +12,7 @@ dotenv.config();
 
 import { getAccountHistory, reEnrichFTBalances, repairMissingStakingRecordsV2, repairInvalidStakingRewards, repairStakingDepositsWithoutTxHash, repairNullTimestamps } from './get-account-history.js';
 import { convertJsonToCsv } from './json-to-csv.js';
-import { callViewFunction } from './rpc.js';
+import { callViewFunction, getCurrentBlockHeight, getBlockTimestamp } from './rpc.js';
 import { detectGapsV2 } from './gap-detection.js';
 import { migrateToV2 } from './migrate-to-flat-format.js';
 import { isStakingPool } from './balance-tracker.js';
@@ -777,9 +777,54 @@ export async function startWorker(config: WorkerConfig = {}): Promise<WorkerHand
                 // and intents deposits (see transfers-sync.ts). Incremental after
                 // the latest stored owned block.
                 try {
-                    const txSync = await syncFtTransfersForAccount(accountId, outputFile);
+                    // Tail reconciliation against live ft_balance_of catches
+                    // non-transfer disposals (burns/redemptions, e.g. stNEAR
+                    // unstake via meta-pool) that leave no ft_transfer and so end
+                    // the ledger at a stale balance. Only for complete accounts:
+                    // incomplete ones are still being backfilled (probing would
+                    // fight the in-progress ledger and waste RPC). One head-block
+                    // lookup per account per cycle; one ft_balance_of per owned FT
+                    // token whose tail differs from chain.
+                    let reconcile;
+                    if (historyComplete) {
+                        try {
+                            const head = await getCurrentBlockHeight();
+                            const headTs = await getBlockTimestamp(head);
+                            reconcile = {
+                                probe: (tokenId: string, acct: string, block: number) =>
+                                    callViewFunction(tokenId, 'ft_balance_of', { account_id: acct }, block),
+                                block: head,
+                                timestamp: headTs ? new Date(Math.floor(headTs / 1_000_000)).toISOString() : null,
+                                // Date corrections at the block where the balance
+                                // actually moved (bisection over archival
+                                // ft_balance_of — the default RPC endpoint is
+                                // archival) so realizations land on the right day,
+                                // not the detection day. Falls back to head-
+                                // stamping inside the reconciler if archival
+                                // probes fail.
+                                locate: {
+                                    timestampOf: async (block: number) => {
+                                        const ts = await getBlockTimestamp(block);
+                                        return ts ? new Date(Math.floor(ts / 1_000_000)).toISOString() : null;
+                                    },
+                                },
+                            };
+                        } catch (e) {
+                            console.error(`[${accountId}] Reconcile head lookup failed:`, e);
+                        }
+                    }
+                    const txSync = await syncFtTransfersForAccount(accountId, outputFile, { reconcile });
                     if (txSync.changed) {
-                        console.log(`[${accountId}] Transfers sync: +${txSync.fetched} fetched, ${txSync.gaps.length} gap(s), ${txSync.filled} reconciled${txSync.backfilled ? ' (backfill)' : ''}`);
+                        console.log(`[${accountId}] Transfers sync: +${txSync.fetched} fetched, ${txSync.gaps.length} gap(s), ${txSync.filled} filled, ${txSync.reconciled} tail-reconciled${txSync.backfilled ? ' (backfill)' : ''}`);
+                    }
+                    // Never let these fail silently: an unprobed tail reads as
+                    // "reconciled" when it wasn't (retries next cycle), and a
+                    // dating fallback books the disposal at detection time.
+                    if (txSync.reconcileProbeFailures.length > 0) {
+                        console.warn(`[${accountId}] Tail probe failed (tail NOT verified, retrying next cycle): ${txSync.reconcileProbeFailures.join(', ')}`);
+                    }
+                    if (txSync.reconcileDatingFallbacks.length > 0) {
+                        console.warn(`[${accountId}] Correction dating failed (head-stamped instead): ${txSync.reconcileDatingFallbacks.join(', ')}`);
                     }
                 } catch (error) {
                     console.error(`[${accountId}] Transfers sync failed:`, error);

--- a/scripts/balance-tracker.ts
+++ b/scripts/balance-tracker.ts
@@ -102,6 +102,12 @@ export interface BalanceChangeRecord {
     amount: string;                   // Change amount (positive = in, negative = out)
     balance_before: string;           // Token balance before this block
     balance_after: string;            // Token balance after this block
+
+    // Set on records synthesized by tail reconciliation (see transfers-sync.ts):
+    // a non-transfer balance move (burn/redemption/mint) that happened after the
+    // last transfer, detected by comparing the tail against a live ft_balance_of.
+    // Recomputed every sync cycle, so consumers may treat these as replaceable.
+    reconciled?: boolean;
 }
 
 // Mainnet epoch length in blocks (roughly 12 hours)

--- a/scripts/transfers-sync.ts
+++ b/scripts/transfers-sync.ts
@@ -302,6 +302,279 @@ export async function mergeFtTransferRecords(
     return { records, fetched: ownedFetched.length, gaps, filled };
 }
 
+/**
+ * Probe the live on-chain balance of an owned FT token for `accountId` at `block`.
+ * Returns the raw balance string, or null if it can't be read (treated as "skip
+ * this token this cycle"). Injected so the module stays RPC-free and testable.
+ */
+export type BalanceProbe = (
+    tokenId: string,
+    accountId: string,
+    block: number
+) => Promise<string | null>;
+
+export interface ReconcileOptions {
+    probe: BalanceProbe;
+    /** Block to probe at — the current chain head. */
+    block: number;
+    /** ISO timestamp of `block`, stamped onto synthesized records (may be null). */
+    timestamp: string | null;
+    /**
+     * When provided, a NEW discrepancy is DATED by binary-searching `probe` over
+     * (lastRealBlock, block] for the block(s) where the balance actually moved,
+     * instead of stamping the correction at the probe head. Requires an archival-
+     * capable RPC behind the probe (old blocks). Without it, corrections are
+     * booked at detection time — right balance, wrong date, which skews the
+     * realization's price date (and potentially its fiscal year) in reports.
+     * Runs only when a discrepancy is first detected, not on reuse cycles
+     * (~log2(range) probes per change-point).
+     */
+    locate?: {
+        /** Resolve a block's ISO timestamp for the dated record (may return null). */
+        timestampOf: (block: number) => Promise<string | null>;
+        /** Change-points to date before lumping the remainder at the head (default 4). */
+        maxTransitions?: number;
+    };
+}
+
+export interface ReconcileResult {
+    /** Records with stale reconciliations dropped and fresh ones appended. */
+    records: BalanceChangeRecord[];
+    /** Number of tokens carrying reconciliation records after this pass. */
+    reconciled: number;
+    /** Whether the record set actually changed (drives the file write). */
+    modified: boolean;
+    /**
+     * Tokens whose head probe failed or returned null — their tail was NOT
+     * verified this pass (any prior correction was kept). Non-empty output must
+     * be surfaced, not swallowed: a silent skip reads as "reconciled" when it
+     * wasn't. Self-heals on the next cycle if the failure was transient.
+     */
+    probeFailures: string[];
+    /** Tokens whose correction was head-stamped because dating (bisection) failed. */
+    datingFallbacks: string[];
+}
+
+/**
+ * Reconcile each owned FT token's TAIL balance against the live chain.
+ *
+ * `detectTokenGaps` only checks continuity BETWEEN consecutive records, so a
+ * non-transfer balance move that happens AFTER the last transfer — with no later
+ * transfer to expose the discontinuity — is invisible. The canonical case is a
+ * liquid-staking redemption/unstake (e.g. meta-pool.near stNEAR) that BURNS the
+ * token: no ft_transfer, so the transfers-API ledger simply ends at the stale
+ * pre-burn balance and every consumer keeps showing it.
+ *
+ * For each bare FT contract (isFtToken — intents balances have no per-account
+ * ft_balance_of; NEAR and staking pools aren't owned) we take the latest real
+ * record's balance_after and compare it to ft_balance_of at the chain head. On a
+ * mismatch we synthesize a correcting record (amount = on-chain − tail) so the
+ * running balance reconciles to chain.
+ *
+ * Idempotent and self-healing: prior reconciliation records are stripped and
+ * recomputed from the latest REAL tail each cycle, so a late-indexed transfer
+ * (settlement lag) transparently supersedes a reconciliation instead of leaving a
+ * gap. A reconciliation whose (tail, on-chain) pair is unchanged is reused as-is,
+ * so a steady state doesn't churn the file.
+ */
+export async function reconcileFtTailBalances(
+    accountId: string,
+    records: BalanceChangeRecord[],
+    opts: ReconcileOptions
+): Promise<ReconcileResult> {
+    const oldRecon = records.filter(r => r.reconciled);
+    const real = records.filter(r => !r.reconciled);
+
+    // Prior reconciliations grouped per token: a dated correction can span
+    // several change-points, so a token may carry more than one record.
+    const oldReconByToken = new Map<string, BalanceChangeRecord[]>();
+    for (const r of oldRecon) {
+        const list = oldReconByToken.get(r.token_id) || [];
+        list.push(r);
+        oldReconByToken.set(r.token_id, list);
+    }
+    for (const list of oldReconByToken.values()) {
+        list.sort((a, b) => a.block_height - b.block_height);
+    }
+
+    const realByToken = groupByToken(real.filter(r => isFtToken(r.token_id)));
+    const newRecon: BalanceChangeRecord[] = [];
+    let reconciledTokens = 0;
+    let modified = false;
+    const visited = new Set<string>();
+    const probeFailures: string[] = [];
+    const datingFallbacks: string[] = [];
+
+    // Keep a token's prior reconciliation untouched (probe unavailable, or the
+    // tail hasn't moved past it) — reused by reference, so not a modification.
+    const keepPrior = (token: string) => {
+        const prior = oldReconByToken.get(token);
+        if (prior) {
+            newRecon.push(...prior);
+            reconciledTokens++;
+        }
+    };
+
+    for (const [token, recs] of realByToken) {
+        visited.add(token);
+        const latest = recs.reduce((a, b) => (b.block_height > a.block_height ? b : a));
+        // The probe block must be strictly ahead of everything we already know, or
+        // we'd be asserting a balance for a block a real record already covers.
+        if (latest.block_height >= opts.block) {
+            keepPrior(token);
+            continue;
+        }
+
+        let onChain: string | null;
+        try {
+            onChain = await opts.probe(token, accountId, opts.block);
+        } catch {
+            // Transient RPC failure: keep any prior reconciliation for this token
+            // (don't regress it to stale-but-unflagged) and move on.
+            probeFailures.push(token);
+            keepPrior(token);
+            continue;
+        }
+        if (onChain == null) {
+            probeFailures.push(token);
+            keepPrior(token);
+            continue;
+        }
+
+        const known = BigInt(latest.balance_after);
+        const actual = BigInt(onChain);
+        const prior = oldReconByToken.get(token);
+
+        if (actual === known) {
+            // Tail matches chain: any prior correction is now redundant (a real
+            // transfer superseded it, or the balance round-tripped back).
+            if (prior) modified = true;
+            continue;
+        }
+
+        // Reuse the prior correction set as-is if it already bridges this exact
+        // (tail → on-chain) span, so a steady state doesn't churn the file or
+        // re-run the (archival-probing) dating search every cycle.
+        if (
+            prior &&
+            prior[0]!.balance_before === known.toString() &&
+            prior[prior.length - 1]!.balance_after === actual.toString()
+        ) {
+            newRecon.push(...prior);
+            reconciledTokens++;
+            continue;
+        }
+
+        modified = true;
+        reconciledTokens++;
+        const synth = await synthesizeCorrections(accountId, token, latest.block_height, known, actual, opts);
+        if (!synth.datedOk) datingFallbacks.push(token);
+        newRecon.push(...synth.records);
+    }
+
+    // Prior reconciliations for tokens that no longer have a real base record are
+    // dropped (a backfill replaced the token's history) — that's a modification.
+    for (const token of oldReconByToken.keys()) {
+        if (!visited.has(token)) modified = true;
+    }
+
+    if (!modified) {
+        return { records, reconciled: reconciledTokens, modified: false, probeFailures, datingFallbacks };
+    }
+
+    const merged = [...real, ...newRecon].sort((a, b) => b.block_height - a.block_height);
+    return { records: merged, reconciled: reconciledTokens, modified: true, probeFailures, datingFallbacks };
+}
+
+/**
+ * Build the correcting record(s) for one token whose tail balance (`known`, at
+ * `tailBlock`) differs from the on-chain balance (`actual`, at `opts.block`).
+ *
+ * Without opts.locate: a single record stamped at the probe head — the running
+ * balance becomes correct, but the disposal is booked at DETECTION time.
+ *
+ * With opts.locate: binary-search the probe over (tailBlock, opts.block] for the
+ * block where the balance actually moved, so the correction lands on the real
+ * change date (the right price date for accounting). A bisection finds one
+ * transition, so multiple change-points are dated iteratively — each search
+ * resumes from the previous find — up to maxTransitions, after which the
+ * remainder is lumped into a final head-stamped record. Balances that changed
+ * and changed back between probes cancel out and are invisible, which is fine:
+ * the net ledger is what's being reconciled. Any probe failure during the search
+ * falls back to the single head-stamped record — the balance correction must not
+ * be lost just because dating it failed.
+ */
+async function synthesizeCorrections(
+    accountId: string,
+    token: string,
+    tailBlock: number,
+    known: bigint,
+    actual: bigint,
+    opts: ReconcileOptions
+): Promise<{ records: BalanceChangeRecord[]; datedOk: boolean }> {
+    const mkRecord = (
+        block: number,
+        timestamp: string | null,
+        before: bigint,
+        after: bigint
+    ): BalanceChangeRecord => ({
+        block_height: block,
+        block_timestamp: timestamp,
+        tx_hash: null,
+        tx_block: null,
+        signer_id: null,
+        receiver_id: null,
+        predecessor_id: null,
+        token_id: token,
+        receipt_id: null,
+        counterparty: null,
+        amount: (after - before).toString(),
+        balance_before: before.toString(),
+        balance_after: after.toString(),
+        reconciled: true,
+    });
+
+    if (!opts.locate) {
+        // Dating not requested — head-stamping is the expected outcome, not a fallback.
+        return { records: [mkRecord(opts.block, opts.timestamp, known, actual)], datedOk: true };
+    }
+
+    try {
+        const maxTransitions = opts.locate.maxTransitions ?? 4;
+        const fixes: BalanceChangeRecord[] = [];
+        let curBlock = tailBlock;
+        let curBal = known;
+        for (let t = 0; t < maxTransitions && curBal !== actual; t++) {
+            // Invariant: balance(curBlock) === curBal, balance(opts.block) === actual ≠ curBal.
+            let lo = curBlock;
+            let hi = opts.block;
+            let hiBal = actual;
+            while (hi - lo > 1) {
+                const mid = lo + Math.floor((hi - lo) / 2);
+                const midRaw = await opts.probe(token, accountId, mid);
+                if (midRaw == null) throw new Error(`probe returned null at block ${mid}`);
+                const midBal = BigInt(midRaw);
+                if (midBal === curBal) {
+                    lo = mid;
+                } else {
+                    hi = mid;
+                    hiBal = midBal;
+                }
+            }
+            fixes.push(mkRecord(hi, await opts.locate.timestampOf(hi), curBal, hiBal));
+            curBlock = hi;
+            curBal = hiBal;
+        }
+        // More change-points than we're willing to date: lump the rest at the head.
+        if (curBal !== actual) {
+            fixes.push(mkRecord(opts.block, opts.timestamp, curBal, actual));
+        }
+        return { records: fixes, datedOk: true };
+    } catch {
+        return { records: [mkRecord(opts.block, opts.timestamp, known, actual)], datedOk: false };
+    }
+}
+
 export interface FillGapsResult {
     /** Full record set with gapped owned tokens repaired from the API ledger. */
     records: BalanceChangeRecord[];
@@ -378,10 +651,15 @@ export async function fillOwnedGapsFromApi(
  * NEAR-only accounts (no FT/intents) get a boundary of 0 and re-fetch their whole
  * transfer history every cycle. Safe after a full backfill, since everything up
  * to this block has already been fetched. 0 if none.
+ *
+ * Reconciliation records are excluded: they carry the probe block (chain head at
+ * sync time), not a fetched transfer — counting them would advance the boundary
+ * past real transfers the API indexes with lag, so they'd never be fetched.
  */
 export function latestSyncedBlock(records: BalanceChangeRecord[]): number {
     let max = 0;
     for (const r of records) {
+        if (r.reconciled) continue;
         if ((isTransfersOwned(r.token_id) || r.token_id === 'near') && r.block_height > max) {
             max = r.block_height;
         }
@@ -410,6 +688,14 @@ export interface SyncOptions extends MergeOptions {
     ) => Promise<BalanceChangeRecord[]>;
     /** Timestamp for updatedAt (ISO string). */
     now?: string;
+    /**
+     * Opt-in tail reconciliation against live ft_balance_of. When provided, after
+     * the transfer merge each owned FT token's tail is compared to on-chain and a
+     * correcting record is synthesized on mismatch (see reconcileFtTailBalances) —
+     * this is what catches burn-style disposals (e.g. stNEAR redemptions) the
+     * transfers API can't represent. Omit to keep sync purely transfer-driven.
+     */
+    reconcile?: ReconcileOptions;
 }
 
 export interface SyncResult extends MergeResult {
@@ -419,6 +705,12 @@ export interface SyncResult extends MergeResult {
     changed: boolean;
     /** Whether this run performed the one-time full backfill. */
     backfilled: boolean;
+    /** Tokens carrying a tail-reconciliation record after this run. */
+    reconciled: number;
+    /** Tokens whose tail could NOT be verified this run (probe failed). */
+    reconcileProbeFailures: string[];
+    /** Tokens corrected with a head-stamped record because dating failed. */
+    reconcileDatingFallbacks: string[];
 }
 
 /**
@@ -437,17 +729,28 @@ export async function syncFtTransfersForAccount(
     const fetchRecords = opts.fetchRecords ?? getAccountTransferRecords;
 
     if (!fs.existsSync(outputFile)) {
-        return { records: [], fetched: 0, gaps: [], filled: 0, afterBlock: 0, changed: false, backfilled: false };
+        return { records: [], fetched: 0, gaps: [], filled: 0, afterBlock: 0, changed: false, backfilled: false, reconciled: 0, reconcileProbeFailures: [], reconcileDatingFallbacks: [] };
     }
 
     const data = JSON.parse(fs.readFileSync(outputFile, 'utf-8'));
     if (data.version !== 2 || !Array.isArray(data.records)) {
         // Sync operates on the flat V2 format only.
-        return { records: data.records ?? [], fetched: 0, gaps: [], filled: 0, afterBlock: 0, changed: false, backfilled: false };
+        return { records: data.records ?? [], fetched: 0, gaps: [], filled: 0, afterBlock: 0, changed: false, backfilled: false, reconciled: 0, reconcileProbeFailures: [], reconcileDatingFallbacks: [] };
     }
 
-    const existing: BalanceChangeRecord[] = data.records;
+    const allExisting: BalanceChangeRecord[] = data.records;
     data.metadata = data.metadata || {};
+
+    // Reconciliation records (reconcileFtTailBalances) are EPHEMERAL: they are
+    // recomputed from the real tail every cycle. Strip them before merging so they
+    // never advance the incremental watermark, shadow a real fetched transfer in
+    // the merge dedup (their ftKey can collide), or bridge — and thereby mask —
+    // the very balance gap that fillOwnedGapsFromApi needs to see to recover a
+    // late-indexed real transfer. They are re-derived (or reused unchanged) after
+    // the merge. Without opts.reconcile they pass through untouched, so turning
+    // the feature off does not silently delete prior corrections.
+    const oldRecon = opts.reconcile ? allExisting.filter(r => r.reconciled) : [];
+    const existing = opts.reconcile ? allExisting.filter(r => !r.reconciled) : allExisting;
 
     // Two-phase sync (applies to owned tokens: FT + NEAR Intents balances):
     //
@@ -485,6 +788,25 @@ export async function syncFtTransfersForAccount(
         };
     }
 
+    // Tail reconciliation (opt-in): catch non-transfer disposals (burns/
+    // redemptions) that land after the last transfer, which detectTokenGaps can't
+    // see. Runs on the merged+repaired ledger so it reconciles against the real
+    // latest tail, not a stale one.
+    let reconciled = 0;
+    let reconcileModified = false;
+    let reconcileProbeFailures: string[] = [];
+    let reconcileDatingFallbacks: string[] = [];
+    if (opts.reconcile) {
+        // Old reconciliations ride along only for the unchanged-reuse check; the
+        // merged result itself is recon-free (purged on read above).
+        const rec = await reconcileFtTailBalances(accountId, [...result.records, ...oldRecon], opts.reconcile);
+        reconciled = rec.reconciled;
+        reconcileModified = rec.modified;
+        reconcileProbeFailures = rec.probeFailures;
+        reconcileDatingFallbacks = rec.datingFallbacks;
+        result = { ...result, records: rec.records };
+    }
+
     // Genuinely-missing FT data keeps the account "incomplete" so the sync loop
     // re-visits it frequently until the transfers API has indexed the credit.
     // (Intents block-level gaps are expected — several settlements per block — and
@@ -493,14 +815,18 @@ export async function syncFtTransfersForAccount(
     const flipIncomplete = unfilledFtGaps.length > 0 && data.metadata.historyComplete === true;
 
     const changed =
-        result.records.length !== existing.length ||
+        result.records.length !== allExisting.length ||
         result.fetched > 0 ||
         result.filled > 0 ||
         needsBackfill ||
-        flipIncomplete;
+        flipIncomplete ||
+        reconcileModified;
 
     if (changed) {
-        const blocks = result.records.map(r => r.block_height);
+        // Block-range metadata reflects real history only: a reconciliation record
+        // carries the probe block (the chain head at sync time), which would drag
+        // lastBlock to "now" on every correction.
+        const blocks = result.records.filter(r => !r.reconciled).map(r => r.block_height);
         data.records = result.records;
         if (blocks.length > 0) {
             data.metadata.firstBlock = Math.min(...blocks);
@@ -516,5 +842,8 @@ export async function syncFtTransfersForAccount(
         fs.writeFileSync(outputFile, JSON.stringify(data, null, 2));
     }
 
-    return { ...result, afterBlock, changed, backfilled: needsBackfill };
+    return {
+        ...result, afterBlock, changed, backfilled: needsBackfill,
+        reconciled, reconcileProbeFailures, reconcileDatingFallbacks,
+    };
 }

--- a/test/unit/transfers-sync.test.ts
+++ b/test/unit/transfers-sync.test.ts
@@ -10,9 +10,11 @@ import {
     isTransfersOwned,
     latestSyncedBlock,
     mergeFtTransferRecords,
+    reconcileFtTailBalances,
     syntheticGapSampler,
     syncFtTransfersForAccount,
     tokenIdToAssetId,
+    type BalanceProbe,
 } from '../../scripts/transfers-sync.js';
 import type { BalanceChangeRecord } from '../../scripts/balance-tracker.js';
 
@@ -60,6 +62,14 @@ describe('token classification', function () {
 });
 
 describe('latestSyncedBlock', function () {
+    it('ignores reconciliation records (they carry the probe block, not a fetched transfer)', () => {
+        const records = [
+            rec({ token_id: 'token.near', block_height: 100 }),
+            { ...rec({ token_id: 'token.near', block_height: 999 }), reconciled: true },
+        ];
+        assert.equal(latestSyncedBlock(records), 100);
+    });
+
     it('returns the max block among FT + intents + NEAR (not staking)', () => {
         const records = [
             rec({ token_id: 'npro.nearmobile.near', block_height: 100 }),       // FT
@@ -343,6 +353,374 @@ describe('syncFtTransfersForAccount', function () {
         fs.writeFileSync(file, JSON.stringify({ accountId: 'a', transactions: [] }));
         const result = await syncFtTransfersForAccount('a', file, { fetchRecords: async () => { throw new Error('should not fetch'); } });
         assert.equal(result.changed, false);
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+});
+
+describe('reconcileFtTailBalances', function () {
+    // Probe that returns a fixed on-chain balance per token; records the calls.
+    const probeOf = (balances: Record<string, string | null>, calls?: string[]): BalanceProbe =>
+        async (tokenId) => { calls?.push(tokenId); return balances[tokenId] ?? null; };
+
+    it('synthesizes a correcting record for a burned tail (the stNEAR case)', async () => {
+        // Last transfer left 287 stNEAR; on-chain it's now 0 (redeemed via meta-pool
+        // — a burn, no ft_transfer, so no later record and detectTokenGaps is blind).
+        const records = [
+            rec({ token_id: 'meta-pool.near', block_height: 100, amount: '287', balance_before: '0', balance_after: '287' }),
+        ];
+        const res = await reconcileFtTailBalances('acct.near', records, {
+            probe: probeOf({ 'meta-pool.near': '0' }),
+            block: 500,
+            timestamp: '2026-07-21T00:00:00.000Z',
+        });
+        assert.equal(res.modified, true);
+        assert.equal(res.reconciled, 1);
+        const fix = res.records.find(r => r.reconciled);
+        assert.ok(fix, 'a reconciliation record was added');
+        assert.equal(fix!.token_id, 'meta-pool.near');
+        assert.equal(fix!.balance_before, '287');
+        assert.equal(fix!.balance_after, '0');
+        assert.equal(fix!.amount, '-287');
+        assert.equal(fix!.block_height, 500);
+        assert.equal(fix!.tx_hash, null);
+        assert.equal(fix!.block_timestamp, '2026-07-21T00:00:00.000Z');
+    });
+
+    it('does nothing when the tail already matches chain', async () => {
+        const records = [
+            rec({ token_id: 'npro.nearmobile.near', block_height: 100, amount: '10', balance_after: '10' }),
+        ];
+        const res = await reconcileFtTailBalances('acct.near', records, {
+            probe: probeOf({ 'npro.nearmobile.near': '10' }),
+            block: 500, timestamp: 't',
+        });
+        assert.equal(res.modified, false);
+        assert.equal(res.reconciled, 0);
+        assert.ok(!res.records.some(r => r.reconciled));
+    });
+
+    it('is idempotent: re-running with the same chain balance does not churn', async () => {
+        const records = [
+            rec({ token_id: 'meta-pool.near', block_height: 100, amount: '287', balance_after: '287' }),
+        ];
+        const first = await reconcileFtTailBalances('acct.near', records, {
+            probe: probeOf({ 'meta-pool.near': '0' }), block: 500, timestamp: 't',
+        });
+        assert.equal(first.modified, true);
+        // Feed the reconciled set back in at a later head; nothing changed on-chain.
+        const second = await reconcileFtTailBalances('acct.near', first.records, {
+            probe: probeOf({ 'meta-pool.near': '0' }), block: 600, timestamp: 't2',
+        });
+        assert.equal(second.modified, false, 'unchanged on-chain -> no rewrite');
+        assert.equal(second.records.filter(r => r.reconciled).length, 1);
+    });
+
+    it('a late-indexed real transfer supersedes the reconciliation', async () => {
+        // Cycle 1: burn reconciled to 0.
+        const c1 = await reconcileFtTailBalances('acct.near', [
+            rec({ token_id: 'meta-pool.near', block_height: 100, amount: '287', balance_after: '287' }),
+        ], { probe: probeOf({ 'meta-pool.near': '0' }), block: 500, timestamp: 't' });
+        assert.equal(c1.records.filter(r => r.reconciled).length, 1);
+
+        // Cycle 2: the transfers API finally indexed the real out-transfer (287 -> 0)
+        // at block 300. The persisted file still carries cycle 1's reconciliation,
+        // so it's part of the input and must be dropped now the real tail matches.
+        const withRealTransfer = [
+            ...c1.records,
+            rec({ token_id: 'meta-pool.near', block_height: 300, amount: '-287', balance_before: '287', balance_after: '0', receipt_id: 'REAL' }),
+        ];
+        const c2 = await reconcileFtTailBalances('acct.near', withRealTransfer, {
+            probe: probeOf({ 'meta-pool.near': '0' }), block: 600, timestamp: 't2',
+        });
+        assert.equal(c2.modified, true, 'stale reconciliation dropped');
+        assert.ok(!c2.records.some(r => r.reconciled), 'no reconciliation once real tail matches chain');
+    });
+
+    it('does not probe intents, NEAR, or staking-pool tokens', async () => {
+        const calls: string[] = [];
+        const records = [
+            rec({ token_id: 'nep141:usdc.near', block_height: 100, balance_after: '50' }),
+            rec({ token_id: 'near', block_height: 100, balance_after: '9' }),
+            rec({ token_id: 'astro.poolv1.near', block_height: 100, balance_after: '7' }),
+        ];
+        const res = await reconcileFtTailBalances('acct.near', records, {
+            probe: probeOf({}, calls), block: 500, timestamp: 't',
+        });
+        assert.deepEqual(calls, [], 'no ft_balance_of calls for non-owned/unprobeable tokens');
+        assert.equal(res.modified, false);
+    });
+
+    it('keeps a prior reconciliation when the probe fails transiently', async () => {
+        const seeded = await reconcileFtTailBalances('acct.near', [
+            rec({ token_id: 'meta-pool.near', block_height: 100, amount: '287', balance_after: '287' }),
+        ], { probe: probeOf({ 'meta-pool.near': '0' }), block: 500, timestamp: 't' });
+
+        const failing: BalanceProbe = async () => { throw new Error('rpc down'); };
+        const res = await reconcileFtTailBalances('acct.near', seeded.records, {
+            probe: failing, block: 600, timestamp: 't2',
+        });
+        assert.equal(res.records.filter(r => r.reconciled).length, 1, 'prior reconciliation retained');
+        assert.equal(res.modified, false);
+        assert.deepEqual(res.probeFailures, ['meta-pool.near'], 'unverified tail is reported, not silent');
+    });
+
+    // Probe backed by a balance timeline: fn(block) -> raw balance at that block.
+    const timelineProbe = (fn: (block: number) => string): BalanceProbe =>
+        async (_token, _acct, block) => fn(block);
+    const tsOf = async (block: number) => `ts-${block}`;
+
+    it('locate: dates the correction at the actual change block via bisection', async () => {
+        // Balance was 287 through block 450, 0 from 451 on (the burn block).
+        const records = [
+            rec({ token_id: 'meta-pool.near', block_height: 100, amount: '287', balance_before: '0', balance_after: '287' }),
+        ];
+        const res = await reconcileFtTailBalances('acct.near', records, {
+            probe: timelineProbe(b => (b <= 450 ? '287' : '0')),
+            block: 1000,
+            timestamp: 't-head',
+            locate: { timestampOf: tsOf },
+        });
+        const fix = res.records.find(r => r.reconciled);
+        assert.ok(fix);
+        assert.equal(fix!.block_height, 451, 'dated at the actual burn block, not the probe head');
+        assert.equal(fix!.block_timestamp, 'ts-451');
+        assert.equal(fix!.amount, '-287');
+        assert.equal(fix!.balance_before, '287');
+        assert.equal(fix!.balance_after, '0');
+    });
+
+    it('locate: dates multiple change-points as separate chained records', async () => {
+        // 10 through 300, 5 through 600, 0 after — two distinct disposals.
+        const records = [
+            rec({ token_id: 'token.near', block_height: 100, amount: '10', balance_before: '0', balance_after: '10' }),
+        ];
+        const res = await reconcileFtTailBalances('acct.near', records, {
+            probe: timelineProbe(b => (b <= 300 ? '10' : b <= 600 ? '5' : '0')),
+            block: 1000,
+            timestamp: 't-head',
+            locate: { timestampOf: tsOf },
+        });
+        const fixes = res.records.filter(r => r.reconciled).sort((a, b) => a.block_height - b.block_height);
+        assert.equal(fixes.length, 2);
+        assert.deepEqual(
+            fixes.map(f => [f.block_height, f.amount, f.balance_before, f.balance_after, f.block_timestamp]),
+            [
+                [301, '-5', '10', '5', 'ts-301'],
+                [601, '-5', '5', '0', 'ts-601'],
+            ]
+        );
+    });
+
+    it('locate: lumps the remainder at the head after maxTransitions', async () => {
+        const records = [
+            rec({ token_id: 'token.near', block_height: 100, amount: '10', balance_before: '0', balance_after: '10' }),
+        ];
+        const res = await reconcileFtTailBalances('acct.near', records, {
+            probe: timelineProbe(b => (b <= 300 ? '10' : b <= 600 ? '5' : '0')),
+            block: 1000,
+            timestamp: 't-head',
+            locate: { timestampOf: tsOf, maxTransitions: 1 },
+        });
+        const fixes = res.records.filter(r => r.reconciled).sort((a, b) => a.block_height - b.block_height);
+        assert.equal(fixes.length, 2);
+        // First change-point dated; the rest lumped into a head-stamped record.
+        assert.deepEqual(fixes.map(f => [f.block_height, f.balance_before, f.balance_after, f.block_timestamp]), [
+            [301, '10', '5', 'ts-301'],
+            [1000, '5', '0', 't-head'],
+        ]);
+    });
+
+    it('locate: falls back to a head-stamped correction when archival probes fail', async () => {
+        // Head probe works; any historical (bisect) probe throws.
+        const probe: BalanceProbe = async (_t, _a, block) => {
+            if (block === 1000) return '0';
+            throw new Error('archival unavailable');
+        };
+        const records = [
+            rec({ token_id: 'meta-pool.near', block_height: 100, amount: '287', balance_before: '0', balance_after: '287' }),
+        ];
+        const res = await reconcileFtTailBalances('acct.near', records, {
+            probe, block: 1000, timestamp: 't-head',
+            locate: { timestampOf: tsOf },
+        });
+        const fix = res.records.find(r => r.reconciled);
+        assert.ok(fix, 'the balance correction survives a dating failure');
+        assert.equal(fix!.block_height, 1000);
+        assert.equal(fix!.block_timestamp, 't-head');
+        assert.equal(fix!.balance_after, '0');
+        assert.deepEqual(res.datingFallbacks, ['meta-pool.near'], 'fallback is reported, not silent');
+        assert.deepEqual(res.probeFailures, []);
+    });
+
+    it('locate: reuses an unchanged multi-record correction set without re-bisecting', async () => {
+        // Prior cycle produced a two-record dated correction (10 -> 5 -> 0).
+        const records = [
+            rec({ token_id: 'token.near', block_height: 100, amount: '10', balance_before: '0', balance_after: '10' }),
+            { ...rec({ token_id: 'token.near', block_height: 301, amount: '-5', balance_before: '10', balance_after: '5' }), tx_hash: null, reconciled: true },
+            { ...rec({ token_id: 'token.near', block_height: 601, amount: '-5', balance_before: '5', balance_after: '0' }), tx_hash: null, reconciled: true },
+        ];
+        // Probe only tolerates the head query — a bisect probe would throw.
+        const probe: BalanceProbe = async (_t, _a, block) => {
+            if (block === 2000) return '0';
+            throw new Error('unexpected historical probe on a reuse cycle');
+        };
+        const res = await reconcileFtTailBalances('acct.near', records, {
+            probe, block: 2000, timestamp: 't-head2',
+            locate: { timestampOf: async () => { throw new Error('should not be called'); } },
+        });
+        assert.equal(res.modified, false, 'unchanged span -> reuse, no churn');
+        assert.equal(res.records.filter(r => r.reconciled).length, 2);
+    });
+
+    it('does not probe a tail at or beyond the probe block', async () => {
+        const calls: string[] = [];
+        const records = [
+            rec({ token_id: 'meta-pool.near', block_height: 500, amount: '287', balance_after: '287' }),
+        ];
+        const res = await reconcileFtTailBalances('acct.near', records, {
+            probe: probeOf({ 'meta-pool.near': '0' }, calls), block: 500, timestamp: 't',
+        });
+        assert.deepEqual(calls, [], 'no probe when a real record already covers the head block');
+        assert.equal(res.modified, false);
+    });
+});
+
+describe('syncFtTransfersForAccount — tail reconciliation', function () {
+    it('reconciles a burned FT tail end-to-end and writes the correcting record', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ftsync-recon-'));
+        const file = path.join(dir, 'acct.json');
+        fs.writeFileSync(file, JSON.stringify({
+            version: 2,
+            accountId: 'acct.near',
+            records: [
+                rec({ token_id: 'meta-pool.near', block_height: 100, receipt_id: 'ACQ', amount: '287', balance_before: '0', balance_after: '287' }),
+            ],
+            metadata: { firstBlock: 100, lastBlock: 100, totalRecords: 1, ftBackfillVersion: 6, historyComplete: true },
+        }, null, 2));
+
+        const result = await syncFtTransfersForAccount('acct.near', file, {
+            now: '2026-07-21T00:00:00.000Z',
+            fetchRecords: async () => [], // no new transfers
+            reconcile: {
+                probe: async () => '0', // on-chain stNEAR now 0
+                block: 999,
+                timestamp: '2026-07-21T00:00:00.000Z',
+            },
+        });
+
+        assert.equal(result.reconciled, 1);
+        assert.equal(result.changed, true);
+        const written = JSON.parse(fs.readFileSync(file, 'utf-8'));
+        const fix = written.records.find((r: any) => r.reconciled);
+        assert.ok(fix, 'correcting record persisted');
+        assert.equal(fix.balance_after, '0');
+        assert.equal(fix.amount, '-287');
+        // Block-range metadata must reflect real history, not the probe block.
+        assert.equal(written.metadata.lastBlock, 100);
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('purges the old reconciliation on read: it never advances the watermark, and a late-indexed real transfer is fetched and supersedes it', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ftsync-recon2-'));
+        const file = path.join(dir, 'acct.json');
+        // Cycle N left: real tail 10 @100, plus a reconciliation 10 -> 5 stamped at
+        // the then-head block 500 (the API hadn't indexed the real out-transfer yet).
+        fs.writeFileSync(file, JSON.stringify({
+            version: 2,
+            accountId: 'acct.near',
+            records: [
+                rec({ token_id: 'token.near', block_height: 100, receipt_id: 'ACQ', amount: '10', balance_before: '0', balance_after: '10' }),
+                { ...rec({ token_id: 'token.near', block_height: 500, amount: '-5', balance_before: '10', balance_after: '5' }), tx_hash: null, reconciled: true },
+            ],
+            metadata: { firstBlock: 100, lastBlock: 100, totalRecords: 2, ftBackfillVersion: 6, historyComplete: true },
+        }, null, 2));
+
+        let calledAfter: number | undefined;
+        const result = await syncFtTransfersForAccount('acct.near', file, {
+            now: '2026-07-21T00:00:00.000Z',
+            fetchRecords: async (_acct, options) => {
+                calledAfter = options.afterBlock;
+                // The API has now indexed the real transfer (settled at 450, i.e.
+                // BELOW the old reconciliation's block 500).
+                return [rec({ token_id: 'token.near', block_height: 450, receipt_id: 'REAL', amount: '-5', balance_before: '10', balance_after: '5' })];
+            },
+            reconcile: {
+                probe: async () => '3', // chain moved again since: 5 -> 3
+                block: 900,
+                timestamp: '2026-07-21T00:00:00.000Z',
+            },
+        });
+
+        // Watermark from the REAL tail (100), not the old reconciliation (500) —
+        // otherwise the block-450 transfer would never have been fetched.
+        assert.equal(calledAfter, 100);
+        assert.equal(result.changed, true);
+
+        const written = JSON.parse(fs.readFileSync(file, 'utf-8'));
+        const tokenRecs = written.records.filter((r: any) => r.token_id === 'token.near');
+        assert.ok(tokenRecs.some((r: any) => r.receipt_id === 'REAL'), 'late-indexed real transfer ingested');
+        const recons = tokenRecs.filter((r: any) => r.reconciled);
+        assert.equal(recons.length, 1, 'old reconciliation replaced, not accumulated');
+        assert.equal(recons[0].balance_before, '5', 'recomputed from the new real tail');
+        assert.equal(recons[0].balance_after, '3');
+        assert.equal(recons[0].block_height, 900);
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('locate: persists the correction dated at the actual change block', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ftsync-recon4-'));
+        const file = path.join(dir, 'acct.json');
+        fs.writeFileSync(file, JSON.stringify({
+            version: 2,
+            accountId: 'acct.near',
+            records: [
+                rec({ token_id: 'meta-pool.near', block_height: 100, receipt_id: 'ACQ', amount: '287', balance_before: '0', balance_after: '287' }),
+            ],
+            metadata: { firstBlock: 100, lastBlock: 100, totalRecords: 1, ftBackfillVersion: 6, historyComplete: true },
+        }, null, 2));
+
+        const result = await syncFtTransfersForAccount('acct.near', file, {
+            now: '2026-07-21T00:00:00.000Z',
+            fetchRecords: async () => [],
+            reconcile: {
+                probe: async (_t, _a, block) => (block <= 450 ? '287' : '0'),
+                block: 999,
+                timestamp: 't-head',
+                locate: { timestampOf: async (b) => `ts-${b}` },
+            },
+        });
+
+        assert.equal(result.reconciled, 1);
+        const written = JSON.parse(fs.readFileSync(file, 'utf-8'));
+        const fix = written.records.find((r: any) => r.reconciled);
+        assert.equal(fix.block_height, 451, 'disposal booked on the real burn block');
+        assert.equal(fix.block_timestamp, 'ts-451');
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('no-op cycle with an unchanged reconciliation does not rewrite the file', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ftsync-recon3-'));
+        const file = path.join(dir, 'acct.json');
+        fs.writeFileSync(file, JSON.stringify({
+            version: 2,
+            accountId: 'acct.near',
+            records: [
+                rec({ token_id: 'token.near', block_height: 100, amount: '287', balance_before: '0', balance_after: '287' }),
+                { ...rec({ token_id: 'token.near', block_height: 500, amount: '-287', balance_before: '287', balance_after: '0' }), tx_hash: null, reconciled: true },
+            ],
+            metadata: { firstBlock: 100, lastBlock: 100, totalRecords: 2, ftBackfillVersion: 6, historyComplete: true },
+        }, null, 2));
+        const before = fs.readFileSync(file, 'utf-8');
+
+        const result = await syncFtTransfersForAccount('acct.near', file, {
+            now: '2026-07-22T00:00:00.000Z',
+            fetchRecords: async () => [],
+            reconcile: { probe: async () => '0', block: 900, timestamp: 't' },
+        });
+
+        assert.equal(result.changed, false, 'same (tail, on-chain) pair -> reuse, no write');
+        assert.equal(result.reconciled, 1);
+        assert.equal(fs.readFileSync(file, 'utf-8'), before, 'file untouched');
         fs.rmSync(dir, { recursive: true, force: true });
     });
 });


### PR DESCRIPTION
## Problem

The transfers-API sync is transfer-driven, so a balance change with no `ft_transfer` — e.g. a liquid-staking redemption that **burns** the token (meta-pool.near stNEAR) — leaves the ledger ending at a stale pre-burn balance. `detectTokenGaps` can't see it either: it only checks continuity *between* consecutive records, and a tail burn has no later record to expose the discontinuity.

Real case: petersalomonsen.near showed 287.98 stNEAR against 0 on-chain since 2026-04-28 — the portfolio kept reporting a balance that had been redeemed months earlier.

## Fix

`reconcileFtTailBalances()` compares each bare FT token's latest `balance_after` against live `ft_balance_of` at the chain head and synthesizes correcting records (marked `reconciled: true`) on mismatch.

- **Dated at the real change block**: `opts.locate` bisects archival `ft_balance_of` over `(lastRealBlock, head]` per change-point (up to `maxTransitions`, then lumps the rest at the head), so realizations land on the actual disposal date — right price date and fiscal year — not the detection date. Falls back to a head-stamped record if archival probes fail; the balance fix is never lost to a dating failure.
- **Ephemeral by design**: reconciliations are purged on read and recomputed from the real tail every cycle, so they never advance the incremental watermark, shadow a real fetched transfer in the merge dedup, or mask the gap `fillOwnedGapsFromApi` needs to recover a late-indexed transfer. An unchanged (tail → on-chain) span reuses the prior records, so a steady state doesn't churn the file or re-run the dating search.
- **Observable**: probe failures (tail NOT verified; retries next cycle) and dating fallbacks are returned in `SyncResult` and warn-logged, never swallowed.

Wired opt-in into the worker for `historyComplete` accounts only: ~1 `ft_balance_of` per owned FT token per 8h sync pass; bisects run once per new discrepancy (~26 probes each).

## Verification

- 41 unit tests in `transfers-sync.test.ts` (bisect dating, multi-transition, lump cap, fallback, no-churn reuse, watermark/gap-masking regressions); full suite green.
- Run against real account data with production RPC pacing: stNEAR corrected **287.98 → 0 dated at burn block 195928787 (2026-04-28T04:45Z)** — independently confirmed as the exact burn block by manual archival bisection — plus 3 dated NPRO daily reward accruals and 2 dated ARIZ billing burns; zero probe failures, zero dating fallbacks, 295 RPC calls including one-time bisects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)